### PR TITLE
Speed up metrics

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -1,5 +1,6 @@
 {
   "skip_files": [
-    "lib/mix/.*"
+    "lib/mix/.*",
+    "lib/mongoose_push/metrics.ex"
   ]
 }

--- a/lib/mongoose_push.ex
+++ b/lib/mongoose_push.ex
@@ -13,7 +13,7 @@ defmodule MongoosePush do
   require Logger
   alias MongoosePush.Pools
   alias MongoosePush.Metrics
-  use Elixometer
+  use Metrics
 
   @typedoc "Available keys in `request` map"
   @type req_key :: :service | :body | :title | :bagde | :mode | :tag |
@@ -50,7 +50,7 @@ defmodule MongoosePush do
       push_result = module.push(notification, device_id, worker, opts)
 
       push_result
-      |> Metrics.update(~s"push.#{service}.#{mode}")
+      |> Metrics.update(:spiral, [:push, service, mode])
       |> maybe_log
   end
 

--- a/test/mogoose_push_metrics_test.exs
+++ b/test/mogoose_push_metrics_test.exs
@@ -27,8 +27,8 @@ defmodule MongoosePushMetricsTest do
     end
 
     test "'error.reason' increased by failed push with 'atom' reason" do
-      ptest [reason: atom(min: 3, max: 15)], repeat_for: 3 do
-        test_metric(:spiral, ~s"error.#{reason}", {:error, reason})
+      ptest [reason: string(min: 3, max: 15, chars: ?a..?z)], repeat_for: 3 do
+        test_metric(:spiral, ~s"error.#{reason}", {:error, :"#{reason}"})
       end
     end
 
@@ -44,7 +44,7 @@ defmodule MongoosePushMetricsTest do
     with_mock FCM,  [:passthrough], [push: fn(_, _, _, _) -> push_return end] do
     ptest [mode:    choose(from: [value(:dev), value(:prod)]),
            service: choose(from: [value(:fcm), value(:apns)])], repeat_for: 20 do
-      metric_name = ~s"mongoose_push.test.#{type}s.push.#{service}.#{mode}."
+      metric_name = ~s"mongoose_push.#{type}s.push.#{service}.#{mode}."
                     <> metric_suffix
 
       metric_value0 = metric_value(type, metric_name)


### PR DESCRIPTION
Replace functions of `MongoosePush.Metrics` module with macros to speed up construction of metric name (compile time vs runtime).