### PR TITLE
Set log level also in lager if available

### DIFF
--- a/lib/mongoose_push/application.ex
+++ b/lib/mongoose_push/application.ex
@@ -8,10 +8,11 @@ defmodule MongoosePush.Application do
 
   @spec start(atom, list(term)) :: {:ok, pid}
   def start(_type, _args) do
-    # Define workers and child supervisors to be supervised
+    # Logger setup
     loglevel = Confex.get(:mongoose_push, :loglevel, :info)
-    Logger.configure(level: loglevel)
+    set_loglevel(loglevel)
 
+    # Define workers and child supervisors to be supervised
     children = List.flatten(workers())
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
@@ -82,5 +83,18 @@ defmodule MongoosePush.Application do
   end
 
   defp mode(config), do: config[:mode] || :prod
+
+  defp set_loglevel(level) do
+    Logger.configure(level: level)
+
+    # This project uses some Erlang deps, so lager may be present
+    case Code.ensure_loaded?(:lager) do
+      true ->
+        :lager.set_loglevel(:lager_file_backend, level)
+        :lager.set_loglevel(:lager_console_backend, level)
+      false ->
+        :ok
+    end
+  end
 
 end


### PR DESCRIPTION
This PR fixes #22 by setting the log level also in `lager` if is available.