### PR TITLE
Fixup dizalyzer job and reduce number of docker image pushes on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,12 @@ otp_release:
 env:
     - PRESET=exunit MIX_ENV=test
 
+script: tools/travis-test.sh
+
 matrix:
     include:
         - otp_release: 20.0
-          env: PRESET=dialyzer_only
+          env: PRESET=dialyzer MIX_ENV=test
 
 script: tools/travis-test.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ script: tools/travis-test.sh
 
 matrix:
     include:
-        - otp_release: 20.0
+        - stage: test
+          otp_release: 20.0
           env: PRESET=dialyzer MIX_ENV=test
-
-script: tools/travis-test.sh
-
-after_success:
-  - tools/travis-docker.sh
+        - stage: deploy
+          elixir: 1.5.1
+          otp_release: 20.0
+          script: tools/travis-docker.sh

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -6,11 +6,12 @@ case "${PRESET}" in
     mix coveralls.travis
     ;;
   "dialyzer" )
+    mkdir -p .dialyzer
     mix dialyzer
     ;;
   "credo" )
     mix credo --ignore design
     ;;
   * )
-    echo "Unknown PRESET value" || exit 1
+    echo "Unknown PRESET value" && exit 1
 esac


### PR DESCRIPTION
There are two small changes:
* Name of dialyzer "preset" has been fixed - for some time now, because of this, dialyzer job hasn't been starting correctly. 
* Deduplication of docker image builds / pushes using Travis `stages` (Test -> Deploy)
