### PR TITLE
Add support for 'sound' and 'priority' options

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,11 @@ If you happen to have APNS files in `pkcs12` format (.p12 or .pfx extenstion) yo
 ##### Get cert from pkcs12 file
 
     openssl pkcs12 -in YourAPNS.p12 -out YourCERT.pem -nodes -nokeys
-    
+
 #### Get key from pkcs12 file
 
     openssl pkcs12 -in YourAPNS.p12 -out YourKEY.pem -nodes -nocerts
-    
+
 
 
 ## REST API
@@ -219,10 +219,10 @@ As you can imagine, `{device_id}` should be replaced with device ID/Token genera
 ```json
 {
   "service": "apns",
-  "alert": 
+  "alert":
     {
       "body": "notification's text body",
-      "title": "notification's title" 
+      "title": "notification's title"
     }
 }
 ```
@@ -230,6 +230,7 @@ As you can imagine, `{device_id}` should be replaced with device ID/Token genera
 The full list of options contains the following:
 * **service** (*required*, `apns` or `fcm`) - push notifications provider to be used for this notification
 * **mode** (*optional*, `prod` (default) or `dev`) - allows for selecting named pool configured in `MongoosePush`
+* **priority** (*optional*) - Either `normal` or `high`. Those values are used without changes for FCM. For APNS however, `normal` maps to priority `5`, while `high` maps to priority `10`. Please refer to FCM / APNS documentation for more details on those values. By default `priority` is not set at all, therefore the push notification service decides which value is used by default.
 * **topic** (*optional*, `APNS` specific) - if APNS certificate configured in `MongoosePush` allows for multiple applications, this field selects the application. Please refer to `APNS` documentation for more datails
 * **data** (*optional*) - custom JSON structure sent to the target device. For `APNS`, all keys form this stucture are merged into highest level APS message (the one that holds 'aps' key), while for `FCM` the whole `data` json stucture is sent as FCM's `data payload` along with `notification`.
 * **alert** (*optional*) - JSON stucture that if provided will send non-silent notification with the following fields:
@@ -238,6 +239,7 @@ The full list of options contains the following:
   * **click_action** (*optional*) - for `FCM` its `activity` to run when notification is clicked. For `APNS` its `category` to invoke. Please refer to Android/iOS documentation for more details about this action
   * **tag** (*optional*, `FCM` specific) - notifications aggregation key
   * **badge** (*optional*, `APNS` specific) - unread notifications count
+  * **sound** (*optional*) - sound that should be play when notification arrives. Please refer to FCM / APNS documentation for more details.
 
 Please note that either **alert** and **data** has to be provided (also can be both).
 If you only specify **alert**, the request will result in classic, simple notification.

--- a/README.md
+++ b/README.md
@@ -219,8 +219,11 @@ As you can imagine, `{device_id}` should be replaced with device ID/Token genera
 ```json
 {
   "service": "apns",
-  "body": "notification's text body",
-  "title": "notification's title"
+  "alert": 
+    {
+      "body": "notification's text body",
+      "title": "notification's title" 
+    }
 }
 ```
 

--- a/lib/mongoose_push.ex
+++ b/lib/mongoose_push.ex
@@ -41,6 +41,9 @@ defmodule MongoosePush do
   Please consult push notification service provider's documentation for more informations on those
   optional fields.
 
+  Field `:priority` may be used to set priority for message on both FCM and APNS. The values are
+  native for FCM and for APNS - :normal is "5" and :high is 10.
+
   `:mode` option is also specific to APNS but it only selects appropriate
   worker pool (with `:mode` set to either `:prod` or `:dev`).
   Default value to `:mode` is `:prod`.
@@ -52,7 +55,7 @@ defmodule MongoosePush do
       worker = Pools.select_worker(service, mode)
       module = MongoosePush.Application.services()[service]
 
-      # Just make sure both data and alert keys exist for convenience (by may be nil)
+      # Just make sure both data and alert keys exist for convenience (but may be nil)
       request =
         request
         |> Map.put(:alert, request[:alert])

--- a/lib/mongoose_push.ex
+++ b/lib/mongoose_push.ex
@@ -17,7 +17,7 @@ defmodule MongoosePush do
 
   @typedoc "Available keys in `request` map"
   @type req_key :: :service | :mode | :alert | :data | :topic
-  @type alert_key :: :title | :body | :tag | :badge | :click_action
+  @type alert_key :: :title | :body | :tag | :badge | :click_action | :sound
   @type data_key :: atom | String.t
 
   @typedoc "Raw push request. The keys: `:service` and at least one of `:alert` or `:body` are required"
@@ -37,7 +37,7 @@ defmodule MongoosePush do
 
   Field `:data` may conatin any custom data that have to be delivered to the target device, while
   field `:alert`, if present, must contain at least `:title` and `:body`. The `:alert` field may also
-  contain: `:tag` (option specific to FCM service), `:topic` and `:bagde` (specific to APNS).
+  contain: :sound, `:tag` (option specific to FCM service), `:topic` and `:bagde` (specific to APNS).
   Please consult push notification service provider's documentation for more informations on those
   optional fields.
 

--- a/lib/mongoose_push.ex
+++ b/lib/mongoose_push.ex
@@ -16,7 +16,7 @@ defmodule MongoosePush do
   use Metrics
 
   @typedoc "Available keys in `request` map"
-  @type req_key :: :service | :mode | :alert | :data | :topic
+  @type req_key :: :service | :mode | :alert | :data | :topic | :priority
   @type alert_key :: :title | :body | :tag | :badge | :click_action | :sound
   @type data_key :: atom | String.t
 

--- a/lib/mongoose_push/api/v2.ex
+++ b/lib/mongoose_push/api/v2.ex
@@ -12,6 +12,7 @@ defmodule MongoosePush.API.V2 do
   params do
     requires  :service,       type: Atom, values: [:fcm, :apns]
     optional  :mode,          type: Atom, values: [:prod, :dev]
+    optional  :priority,      type: Atom, values: [:normal, :high]
 
     # Only for APNS, alert/data independent
     optional  :topic,         type: String

--- a/lib/mongoose_push/api/v2.ex
+++ b/lib/mongoose_push/api/v2.ex
@@ -22,6 +22,7 @@ defmodule MongoosePush.API.V2 do
       optional  :badge,         type: Integer
       optional  :click_action,  type: String
       optional  :tag,           type: String
+      optional  :sound,         type: String
     end
 
     # Use raw json value to skip all maru's validators

--- a/lib/mongoose_push/service/apns.ex
+++ b/lib/mongoose_push/service/apns.ex
@@ -28,7 +28,8 @@ defmodule MongoosePush.Service.APNS do
         "body" => alert.body
       },
       "badge" => alert[:badge],
-      "category" => alert[:click_action]
+      "category" => alert[:click_action],
+      "sound" => alert[:sound]
     }
     |> Notification.new(device_id, request[:topic], request[:data])
   end

--- a/lib/mongoose_push/service/apns.ex
+++ b/lib/mongoose_push/service/apns.ex
@@ -12,6 +12,8 @@ defmodule MongoosePush.Service.APNS do
   alias MongoosePush.Pools
   alias MongoosePush.Service.APNS.Certificate
 
+  @priority_mapping %{normal: "5", high: "10"}
+
   @spec prepare_notification(String.t(), MongoosePush.request) ::
     Service.notification
   def prepare_notification(device_id, %{alert: nil} = request) do
@@ -32,6 +34,7 @@ defmodule MongoosePush.Service.APNS do
       "sound" => alert[:sound]
     }
     |> Notification.new(device_id, request[:topic], request[:data])
+    |> Notification.put_priority(@priority_mapping[request[:priority]])
   end
 
   @spec push(Service.notification(), String.t(), atom(), Service.options()) ::

--- a/lib/mongoose_push/service/fcm.ex
+++ b/lib/mongoose_push/service/fcm.ex
@@ -18,7 +18,7 @@ defmodule MongoosePush.Service.FCM do
   def prepare_notification(device_id, request) do
     # Setup non-silent notification
     alert = request.alert
-    msg = [:body, :title, :click_action, :tag]
+    msg = [:body, :title, :click_action, :tag, :sound]
     |> Enum.reduce(%{}, fn(field, map) ->
       Map.put(map, field, alert[field])
     end)

--- a/lib/mongoose_push/service/fcm.ex
+++ b/lib/mongoose_push/service/fcm.ex
@@ -9,6 +9,8 @@ defmodule MongoosePush.Service.FCM do
   alias MongoosePush.Pools
   require Logger
 
+  @priority_mapping %{normal: "normal", high: "high"}
+
   @spec prepare_notification(String.t(), MongoosePush.request) ::
     Service.notification
   def prepare_notification(device_id, %{alert: nil} = request) do
@@ -22,7 +24,9 @@ defmodule MongoosePush.Service.FCM do
     |> Enum.reduce(%{}, fn(field, map) ->
       Map.put(map, field, alert[field])
     end)
+
     Notification.new(device_id, msg, request[:data])
+    |> Notification.put_priority(@priority_mapping[request[:priority]])
   end
 
   @spec push(Service.notification(), String.t(), atom(), Service.options()) ::

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"bear": {:hex, :bear, "0.8.5", "e95fca1627cd9e15baf93ce0a52aff16917baf325f0ee65b88cd715376cd2344", [:rebar3], [], "hexpm"},
+%{
+  "bear": {:hex, :bear, "0.8.5", "e95fca1627cd9e15baf93ce0a52aff16917baf325f0ee65b88cd715376cd2344", [:rebar3], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
   "chatterbox": {:git, "https://github.com/rslota/chatterbox.git", "6f223e4b836585bce106ac8d93f84a9decf4568f", []},
@@ -33,7 +34,7 @@
   "mix_docker": {:hex, :mix_docker, "0.5.0", "c7ad34008c43d4a949d69721f39c4d2a2afc509c179926a683117ea8dff8af59", [:mix], [{:distillery, "~> 1.2", [hex: :distillery, repo: "hexpm", optional: false]}], "hexpm"},
   "mock": {:hex, :mock, "0.3.1", "994f00150f79a0ea50dc9d86134cd9ebd0d177ad60bd04d1e46336cdfdb98ff9", [:mix], [{:meck, "~> 0.8.8", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.1.0", "1bad3b959941cc53ffd6f4769a5d2666f9cdf179b2d62826636497d3fbad9ec0", [:rebar3], [], "hexpm"},
-  "pigeon": {:git, "https://github.com/rslota/pigeon.git", "8b734de28b14dbeeeb71c9d1ca24840434e429b7", []},
+  "pigeon": {:git, "https://github.com/rslota/pigeon.git", "ffc2d35592fd9c564efe3a9187481d81caf4842c", []},
   "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "pobox": {:hex, :pobox, "1.0.4", "e695bc3b2b547dd6c8e5a19cb743396e6670e306ad3ff498844738f9418bd686", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
@@ -43,4 +44,5 @@
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
-  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"}}
+  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},
+}

--- a/test/rest_v2_test.exs
+++ b/test/rest_v2_test.exs
@@ -58,8 +58,11 @@ defmodule RestV2Test do
   test "api gets corrent request arguments" do
     with_mock MongoosePush, [push: fn(_, _) -> :ok end] do
       args = %{
-        service: :fcm, mode: :dev, alert: %{body: "body654", title: "title345",
-        badge: 10, tag: "tag123", click_action: "on.click"}, topic: "apns topic"
+        service: :fcm, mode: :dev, topic: "apns topic", priority: :high,
+        alert: %{
+          body: "body654", title: "title345",
+          badge: 10, tag: "tag123", click_action: "on.click", sound: "sound.wav"
+        }
       }
       assert 200 = post(@url, args)
       assert called MongoosePush.push("f534534543", args)
@@ -69,7 +72,8 @@ defmodule RestV2Test do
   test "api gets raw data payload" do
     with_mock MongoosePush, [push: fn(_, _) -> :ok end] do
       args = %{
-        service: :fcm, mode: :dev, alert: %{body: "body654", title: "title345"},
+        service: :fcm, mode: :dev, priority: :normal,
+        alert: %{body: "body654", title: "title345"},
         data: %{"acme1" => "value1", "acme2" => "value2"}
       }
       assert 200 = post(@url, args)


### PR DESCRIPTION
This PR adds support for `sound` and `priority` options for both APSN and FCM. 