### PR TITLE
Retrun 460 on invalid device token

### DIFF
--- a/lib/mongoose_push/api.ex
+++ b/lib/mongoose_push/api.ex
@@ -3,6 +3,9 @@ defmodule MongoosePush.API do
   @spec to_status(:ok | {:error, term}) ::
     {non_neg_integer, %{details: atom | String.t} | nil}
   def to_status(:ok), do: {200, nil}
+  def to_status({:error, :invalid_device_token}) do
+    {401, %{:details => "Invalid device token"}}
+  end
   def to_status({:error, :unable_to_connect}) do
     {503, %{:details => "Please try again later"}}
   end

--- a/lib/mongoose_push/api.ex
+++ b/lib/mongoose_push/api.ex
@@ -4,7 +4,7 @@ defmodule MongoosePush.API do
     {non_neg_integer, %{details: atom | String.t} | nil}
   def to_status(:ok), do: {200, nil}
   def to_status({:error, :invalid_device_token}) do
-    {401, %{:details => "Invalid device token"}}
+    {460, %{:details => "Invalid device token"}}
   end
   def to_status({:error, :unable_to_connect}) do
     {503, %{:details => "Please try again later"}}


### PR DESCRIPTION
This PR makes MongoosePush return 401 instead of 500 on invalid device token error.