### PR TITLE
Use debian:stretch-slim as release docker base

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 
 # set locales
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y locales
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
@@ -11,12 +11,14 @@ ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 # required packages
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+RUN echo 'deb http://deb.debian.org/debian jessie main' >> /etc/apt/sources.list
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y \
     bash \
     bash-completion \
     curl \
     dnsutils \
     libssl1.1 \
+    libssl1.0.0 \
     vim && \
     apt-get clean
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,10 @@
-FROM phusion/baseimage:0.10.1
+FROM debian:stretch-slim
+
+# set locales
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
@@ -10,6 +16,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     bash-completion \
     curl \
     dnsutils \
+    libssl1.1 \
     vim && \
     apt-get clean
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ docker run -v `pwd`/priv:/opt/app/priv \
 Building docker is really easy, just type:
 
 ```bash
-MIX_ENV=prod mix do docker.build, docker.release
+MIX_ENV=prod mix do deps.get, certs.dev, docker.build, docker.release
 ```
 
 As a result of this command you get access to `mongoose_push:release` docker image. You may run it by typing:
@@ -49,7 +49,8 @@ docker run -it --rm mongoose_push:release foreground
 ```
 
 Docker image that you have just built, exposes the port `8443` for the REST API of
-MongoosePush. Also there is a `VOLUME` for path */opt/app* where the whole MongoosePush release is stored. This volume will be handy for injecting `APNS` and REST API certificates.
+MongoosePush. Also there is a `VOLUME` for path */opt/app* where the whole MongoosePush release is stored. This volume will be handy for injecting `APNS` and REST API certificates since by default the
+docker image comes with fake, self-signed certificates.
 
 #### Configuring
 


### PR DESCRIPTION
This fixes #67 . The old base image - phusion/baseimage - is based on Ubuntu 16.04 which doesn't have `libssl1.1` in repository. Now `debian:stretch-slim` will be used with `libssl` 1.1 and 1.0.0. We need to keep the older version, since the `master` release is being build on Travis (Ubuntu 16.04).

This change of base image also reduces size of final docker image from 207MB to 125MB (-40%).