### PR TITLE
Add MongoosePushRuntimeTest

### DIFF
--- a/test/mongoose_push_runtime_test.exs
+++ b/test/mongoose_push_runtime_test.exs
@@ -1,0 +1,24 @@
+defmodule MongoosePushRuntimeTest do
+  use ExUnit.Case
+
+  test "tls ciphers required by apns are available" do
+    # APNS supports only:
+    # - ECDHE-RSA-AES128-GCM-SHA256
+    # - ECDHE-RSA-AES256-GCM-SHA384
+
+    all_ciphers = :ssl.cipher_suites()
+    apns_ciphers = Enum.filter(all_ciphers, fn cipher ->
+      case cipher do
+        {:ecdhe_rsa, :aes_128_gcm, _, :sha256} ->
+          true
+        {:ecdhe_rsa, :aes_256_gcm, _, :sha384} ->
+          true
+        _ ->
+          false
+      end
+    end)
+
+    assert length(apns_ciphers) > 0
+  end
+
+end


### PR DESCRIPTION
This new test suites checks whether runtime system supports all necessary features. Right now this only tests TLS cipher suites required by APNS as this is common issue. 