### PR TITLE
Allow sending time_to_live field

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ The full list of options contains the following:
 * **service** (*required*, `apns` or `fcm`) - push notifications provider to be used for this notification
 * **mode** (*optional*, `prod` (default) or `dev`) - allows for selecting named pool configured in `MongoosePush`
 * **priority** (*optional*) - Either `normal` or `high`. Those values are used without changes for FCM. For APNS however, `normal` maps to priority `5`, while `high` maps to priority `10`. Please refer to FCM / APNS documentation for more details on those values. By default `priority` is not set at all, therefore the push notification service decides which value is used by default.
+* **time_to_live** (*optional*) - Maximum lifespan of an FCM notification. For more details, please, refer to [the official FCM documentation](https://firebase.google.com/docs/cloud-messaging/concept-options#ttl).
 * **mutable_content** (*optional*, `true` / `false` (default)) - Only applicable to APNS. Sets "mutable-content=1" in APNS payload.
 * **topic** (*optional*, `APNS` specific) - if APNS certificate configured in `MongoosePush` allows for multiple applications, this field selects the application. Please refer to `APNS` documentation for more datails
 * **data** (*optional*) - custom JSON structure sent to the target device. For `APNS`, all keys form this stucture are merged into highest level APS message (the one that holds 'aps' key), while for `FCM` the whole `data` json stucture is sent as FCM's `data payload` along with `notification`.

--- a/lib/mongoose_push/api/v2.ex
+++ b/lib/mongoose_push/api/v2.ex
@@ -13,6 +13,7 @@ defmodule MongoosePush.API.V2 do
     requires  :service,         type: Atom, values: [:fcm, :apns]
     optional  :mode,            type: Atom, values: [:prod, :dev]
     optional  :priority,        type: Atom, values: [:normal, :high]
+    optional  :time_to_live,    type: Integer
     optional  :mutable_content, type: Boolean, default: false
 
     # Only for APNS, alert/data independent

--- a/lib/mongoose_push/service/fcm.ex
+++ b/lib/mongoose_push/service/fcm.ex
@@ -29,6 +29,7 @@ defmodule MongoosePush.Service.FCM do
 
     Notification.new(device_id, msg, request[:data])
     |> Notification.put_priority(@priority_mapping[request[:priority]])
+    |> Notification.put_ttl(request[:time_to_live])
   end
 
   @spec push(Service.notification(), String.t(), atom(), Service.options()) ::

--- a/lib/mongoose_push/service/fcm.ex
+++ b/lib/mongoose_push/service/fcm.ex
@@ -16,6 +16,7 @@ defmodule MongoosePush.Service.FCM do
   def prepare_notification(device_id, %{alert: nil} = request) do
     # Setup silent notification
     Notification.new(device_id, nil, request[:data])
+    |> Notification.put_ttl(request[:time_to_live])
     |> Notification.put_priority(@priority_mapping[request[:priority]])
   end
   def prepare_notification(device_id, request) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MongoosePush.Mixfile do
   def project do
     [
       app: :mongoose_push,
-      version: "1.0.2",
+      version: "1.0.3",
       elixir: "~> 1.5",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -25,8 +25,8 @@ defmodule MongoosePush.Mixfile do
 
   defp deps do
     [
-     {:pigeon, github: "rslota/pigeon", ref: "f85b74e"},
      {:chatterbox, github: "joedevivo/chatterbox", ref: "ff0c2e054430d2990b588afa6fb8f2d184dfeaea", override: true},
+     {:pigeon, github: "rslota/pigeon", ref: "2860eee35b58e2d8674f805f1151f57b9faeca21"},
 
      {:maru,  github: "rslota/maru", ref: "54fc038", override: true},
      {:cowboy,  "~> 2.3", override: true},

--- a/mix.lock
+++ b/mix.lock
@@ -37,7 +37,7 @@
   "mix_docker": {:hex, :mix_docker, "0.5.0", "c7ad34008c43d4a949d69721f39c4d2a2afc509c179926a683117ea8dff8af59", [:mix], [{:distillery, "~> 1.2", [hex: :distillery, repo: "hexpm", optional: false]}], "hexpm"},
   "mock": {:hex, :mock, "0.3.1", "994f00150f79a0ea50dc9d86134cd9ebd0d177ad60bd04d1e46336cdfdb98ff9", [:mix], [{:meck, "~> 0.8.8", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.1.0", "1bad3b959941cc53ffd6f4769a5d2666f9cdf179b2d62826636497d3fbad9ec0", [:rebar3], [], "hexpm"},
-  "pigeon": {:git, "https://github.com/rslota/pigeon.git", "f85b74e93ac4c863e34b641d14ccf4ca861ca3b4", [ref: "f85b74e"]},
+  "pigeon": {:git, "https://github.com/rslota/pigeon.git", "635f5cbd2664867cf2315965fccd333264df4116", [ref: "ttl_field"]},
   "plug": {:hex, :plug, "1.5.0", "224b25b4039bedc1eac149fb52ed456770b9678bbf0349cdd810460e1e09195b", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "pobox": {:hex, :pobox, "1.0.4", "e695bc3b2b547dd6c8e5a19cb743396e6670e306ad3ff498844738f9418bd686", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -37,7 +37,7 @@
   "mix_docker": {:hex, :mix_docker, "0.5.0", "c7ad34008c43d4a949d69721f39c4d2a2afc509c179926a683117ea8dff8af59", [:mix], [{:distillery, "~> 1.2", [hex: :distillery, repo: "hexpm", optional: false]}], "hexpm"},
   "mock": {:hex, :mock, "0.3.1", "994f00150f79a0ea50dc9d86134cd9ebd0d177ad60bd04d1e46336cdfdb98ff9", [:mix], [{:meck, "~> 0.8.8", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.1.0", "1bad3b959941cc53ffd6f4769a5d2666f9cdf179b2d62826636497d3fbad9ec0", [:rebar3], [], "hexpm"},
-  "pigeon": {:git, "https://github.com/rslota/pigeon.git", "635f5cbd2664867cf2315965fccd333264df4116", [ref: "ttl_field"]},
+  "pigeon": {:git, "https://github.com/rslota/pigeon.git", "2860eee35b58e2d8674f805f1151f57b9faeca21", [ref: "2860eee35b58e2d8674f805f1151f57b9faeca21"]},
   "plug": {:hex, :plug, "1.5.0", "224b25b4039bedc1eac149fb52ed456770b9678bbf0349cdd810460e1e09195b", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "pobox": {:hex, :pobox, "1.0.4", "e695bc3b2b547dd6c8e5a19cb743396e6670e306ad3ff498844738f9418bd686", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},

--- a/test/mongoose_push_test.exs
+++ b/test/mongoose_push_test.exs
@@ -184,7 +184,7 @@ defmodule MongoosePushTest do
       assert notification.alert[:tag] == fcm_data["tag"]
       assert notification.alert[:sound] == fcm_data["sound"]
       assert notification[:data] == fcm_custom
-      assert notification[:time_to_live] == fcm_data["request_data"]["time_to_live"]
+      assert notification[:time_to_live] == fcm_request["request_data"]["time_to_live"]
     end
   end
 

--- a/test/mongoose_push_test.exs
+++ b/test/mongoose_push_test.exs
@@ -147,7 +147,7 @@ defmodule MongoosePushTest do
         tag: string(min: 3, max: 15, chars: :ascii),
         sound: string(min: 3, max: 15, chars: :ascii),
         click_action: string(min: 3, max: 15, chars: :ascii),
-        time_to_live: int(min: 0, max: 4500),
+        time_to_live: int(min: 0, max: 2419200),
         priority: choose(from: [value(:normal), value(:high)]),
       ], repeat_for: 10 do
 

--- a/test/mongoose_push_test.exs
+++ b/test/mongoose_push_test.exs
@@ -147,12 +147,14 @@ defmodule MongoosePushTest do
         tag: string(min: 3, max: 15, chars: :ascii),
         sound: string(min: 3, max: 15, chars: :ascii),
         click_action: string(min: 3, max: 15, chars: :ascii),
+        time_to_live: int(min: 0, max: 4500),
         priority: choose(from: [value(:normal), value(:high)]),
       ], repeat_for: 10 do
 
       notification =
         %{:service => :fcm,
           :priority => priority,
+          :time_to_live => time_to_live,
           :alert => %{
             :title => title,
             :body => body,
@@ -182,6 +184,7 @@ defmodule MongoosePushTest do
       assert notification.alert[:tag] == fcm_data["tag"]
       assert notification.alert[:sound] == fcm_data["sound"]
       assert notification[:data] == fcm_custom
+      assert notification[:time_to_live] == fcm_data["request_data"]["time_to_live"]
     end
   end
 

--- a/test/rest_v2_test.exs
+++ b/test/rest_v2_test.exs
@@ -55,10 +55,11 @@ defmodule RestV2Test do
     end
   end
 
-  test "api gets corrent request arguments" do
+  test "api gets correct request arguments" do
     with_mock MongoosePush, [push: fn(_, _) -> :ok end] do
       args = %{
         service: :fcm, mode: :dev, topic: "apns topic", priority: :high, mutable_content: false,
+        time_to_live: 200,
         alert: %{
           body: "body654", title: "title345",
           badge: 10, tag: "tag123", click_action: "on.click", sound: "sound.wav"


### PR DESCRIPTION
This PR relies on merging [this PR](https://github.com/rslota/pigeon/pull/1) to Pigeon.

This PR lets mongooseim send `time_to_live` option in notifications.