### PR TITLE
Hide FCM key from logs

### DIFF
--- a/lib/mongoose_push/service/apns.ex
+++ b/lib/mongoose_push/service/apns.ex
@@ -74,7 +74,7 @@ defmodule MongoosePush.Service.APNS do
       :dev -> :development_endpoint
       :prod -> :production_endpoint
     end
-    Enum.into([{new_key, config[:endpoint]}], config)
+    Keyword.merge([{new_key, config[:endpoint]}], config)
   end
 
   defp announce_subject(config) do
@@ -101,7 +101,7 @@ defmodule MongoosePush.Service.APNS do
           all_topics = Certificate.extract_topics!(config[:cert])
           default_topic = all_topics[:topic]
           Logger.info(~s"Successfully extracted default APNS topic: #{default_topic}")
-          Enum.into([default_topic: default_topic], config)
+          Keyword.merge([default_topic: default_topic], config)
         default_topic ->
           Logger.info(~s"Using user-defined default APNS topic: #{default_topic}")
           config

--- a/lib/mongoose_push/service/fcm.ex
+++ b/lib/mongoose_push/service/fcm.ex
@@ -53,7 +53,7 @@ defmodule MongoosePush.Service.FCM do
   @spec workers({atom, Keyword.t()} | nil) :: list(Supervisor.Spec.spec())
   def workers(nil), do: []
   def workers({pool_name, pool_config}) do
-    Logger.info ~s"Starting FCM pool with API key #{pool_config[:key]}"
+    Logger.info ~s"Starting FCM pool with API key #{filter_secret(pool_config[:key])}"
     pool_size = pool_config[:pool_size]
     Enum.map(1..pool_size, fn(id) ->
       worker_name = Pools.worker_name(:fcm, pool_name, id)
@@ -61,5 +61,16 @@ defmodule MongoosePush.Service.FCM do
                              [worker_name, pool_config], [id: worker_name])
     end)
   end
+
+  defp filter_secret(secret) when is_binary(secret) do
+    prefix = String.slice(secret, 0..2)
+    suffix =
+      secret
+      |> String.slice(3..-1)
+      |> String.slice(-3..-1)
+
+    prefix <> "*******" <> suffix
+  end
+  defp filter_secret(secret), do: secret
 
 end


### PR DESCRIPTION
* FCM server key is now partially hidden in logs for added security
* Some `Enum.into` have been changed to `Keyword.merge` as per compiler
  warning suggestion.