### PR TITLE
Disable colored logs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,7 @@ config :plug, :statuses, %{
 
 lager_formater_config = [:date, 'T', :time, :color, ' [', :severity, '] ', :pid, ' ', :message, '\e[0m\r\n']
 config :lager,
-  colored: true,
+  colored: false,
   handlers: [
     lager_console_backend: [
       level: :info,


### PR DESCRIPTION
ANSI color codes make it harder to parse logs and extract structured information from them.