### PR TITLE
Fix tags support

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,6 +11,7 @@ config :maru, MongoosePush.Router,
     port: {:system, :integer, "PUSH_HTTPS_PORT", 8443},
     keyfile: {:system, :string, "PUSH_HTTPS_KEYFILE", "priv/ssl/fake_key.pem"},
     certfile: {:system, :string, "PUSH_HTTPS_CERTFILE", "priv/ssl/fake_cert.pem"},
+    cacertfile: {:system, :string, "PUSH_HTTPS_CERTFILE", "priv/ssl/fake_cert.pem"},
     acceptors: {:system, :integer, "PUSH_HTTPS_ACCEPTORS", 100},
     otp_app: :mongoose_push
   ]

--- a/lib/mongoose_push/api/v2.ex
+++ b/lib/mongoose_push/api/v2.ex
@@ -16,6 +16,9 @@ defmodule MongoosePush.API.V2 do
     optional(:priority, type: Atom, values: [:normal, :high])
     optional(:time_to_live, type: Integer)
     optional(:mutable_content, type: Boolean, default: false)
+    optional(:tags, type: fn tags ->
+      Enum.map(tags, &String.to_existing_atom(&1))
+    end, default: [])
 
     # Only for APNS, alert/data independent
     optional(:topic, type: String)

--- a/lib/mongoose_push/api/v2.ex
+++ b/lib/mongoose_push/api/v2.ex
@@ -16,9 +16,13 @@ defmodule MongoosePush.API.V2 do
     optional(:priority, type: Atom, values: [:normal, :high])
     optional(:time_to_live, type: Integer)
     optional(:mutable_content, type: Boolean, default: false)
-    optional(:tags, type: fn tags ->
-      Enum.map(tags, &String.to_existing_atom(&1))
-    end, default: [])
+
+    optional(:tags,
+      type: fn tags ->
+        Enum.map(tags, &String.to_existing_atom(&1))
+      end,
+      default: []
+    )
 
     # Only for APNS, alert/data independent
     optional(:topic, type: String)

--- a/lib/mongoose_push/api/v3.ex
+++ b/lib/mongoose_push/api/v3.ex
@@ -43,9 +43,13 @@ defmodule MongoosePush.API.V3 do
     optional(:priority, type: Atom, values: [:normal, :high])
     optional(:time_to_live, type: Integer)
     optional(:mutable_content, type: Boolean, default: false)
-    optional(:tags, type: fn tags ->
-      Enum.map(tags, &String.to_existing_atom(&1))
-    end, default: [])
+
+    optional(:tags,
+      type: fn tags ->
+        Enum.map(tags, &String.to_existing_atom(&1))
+      end,
+      default: []
+    )
 
     # Only for APNS, alert/data independent
     optional(:topic, type: String)

--- a/lib/mongoose_push/api/v3.ex
+++ b/lib/mongoose_push/api/v3.ex
@@ -43,6 +43,9 @@ defmodule MongoosePush.API.V3 do
     optional(:priority, type: Atom, values: [:normal, :high])
     optional(:time_to_live, type: Integer)
     optional(:mutable_content, type: Boolean, default: false)
+    optional(:tags, type: fn tags ->
+      Enum.map(tags, &String.to_existing_atom(&1))
+    end, default: [])
 
     # Only for APNS, alert/data independent
     optional(:topic, type: String)

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule MongoosePush.Mixfile do
   defp deps do
     [
       {:chatterbox, github: "joedevivo/chatterbox", ref: "ff0c2e0", override: true},
-      {:sparrow, github: "esl/sparrow", ref: "f1f0d891e0409ff748fc64b23bfc1b072bf7de50"},
+      {:sparrow, github: "esl/sparrow", ref: "a94d1490cb819c62e147bad8059fbbdf7e8a260e"},
       {:maru, github: "rslota/maru", ref: "54fc038", override: true},
       {:plug_cowboy, "~> 2.0"},
       {:cowboy, "~> 2.3", override: true},

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MongoosePush.Mixfile do
   def project do
     [
       app: :mongoose_push,
-      version: "2.0.0-alpha.3",
+      version: "2.0.0-alpha.4",
       elixir: "~> 1.5",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -51,9 +51,9 @@
   "pollution": {:hex, :pollution, "0.9.2", "3f67542631071c99f807d2a8f9da799c07cd983c902f5357b9e1569c20a26e76", [:mix], [], "hexpm"},
   "quixir": {:hex, :quixir, "0.9.3", "f01c37386b9e1d0526f01a8734a6d7884af294a0ec360f05c24c7171d74632bd", [:mix], [{:pollution, "~> 0.9.2", [hex: :pollution, repo: "hexpm", optional: false]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
-  "sparrow": {:git, "https://github.com/esl/sparrow.git", "f1f0d891e0409ff748fc64b23bfc1b072bf7de50", [ref: "f1f0d891e0409ff748fc64b23bfc1b072bf7de50"]},
+  "sparrow": {:git, "https://github.com/esl/sparrow.git", "a94d1490cb819c62e147bad8059fbbdf7e8a260e", [ref: "a94d1490cb819c62e147bad8059fbbdf7e8a260e"]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},
-  "worker_pool": {:hex, :worker_pool, "3.1.1", "a9bf27cff366999784a3f0657f016ce3a57901490858cca3fb3be1208bf2110d", [:rebar3], [], "hexpm"},
+  "worker_pool": {:hex, :worker_pool, "4.0.1", "8cdebce7e09ecb4f1eb4bbf78aa99248064ac357077668c011ac600599973723", [:rebar3], [], "hexpm"},
 }

--- a/test/rest_v2_test.exs
+++ b/test/rest_v2_test.exs
@@ -15,6 +15,28 @@ defmodule RestV2Test do
     assert 404 = post("/v2/notifications/test", %{})
   end
 
+  test "incorrect tags return 400" do
+    args = %{
+      service: :fcm,
+      mode: :dev,
+      topic: "apns topic",
+      priority: :high,
+      mutable_content: false,
+      time_to_live: 200,
+      tags: ["non existing atom here"],
+      alert: %{
+        body: "body654",
+        title: "title345",
+        badge: 10,
+        tag: "tag123",
+        click_action: "on.click",
+        sound: "sound.wav"
+      }
+    }
+
+    assert 400 = post(@url, args)
+  end
+
   test "incorrect params returns 400" do
     assert 400 = post(@url, %{service: :apns})
     assert 400 = post(@url, %{service: :fcm})
@@ -67,6 +89,7 @@ defmodule RestV2Test do
         priority: :high,
         mutable_content: false,
         time_to_live: 200,
+        tags: [:pool, :type],
         alert: %{
           body: "body654",
           title: "title345",

--- a/test/rest_v3_test.exs
+++ b/test/rest_v3_test.exs
@@ -15,6 +15,28 @@ defmodule RestV3Test do
     assert 404 = post("/v3/notifications/test", %{})
   end
 
+  test "incorrect tags return 400" do
+    args = %{
+      service: :fcm,
+      mode: :dev,
+      topic: "apns topic",
+      priority: :high,
+      mutable_content: false,
+      time_to_live: 200,
+      tags: ["non existing atom here"],
+      alert: %{
+        body: "body654",
+        title: "title345",
+        badge: 10,
+        tag: "tag123",
+        click_action: "on.click",
+        sound: "sound.wav"
+      }
+    }
+
+    assert 400 = post(@url, args)
+  end
+
   test "incorrect params returns 400" do
     assert 400 = post(@url, %{service: :apns})
     assert 400 = post(@url, %{service: :fcm})
@@ -67,6 +89,7 @@ defmodule RestV3Test do
         priority: :high,
         mutable_content: false,
         time_to_live: 200,
+        tags: [:pool, :type],
         alert: %{
           body: "body654",
           title: "title345",


### PR DESCRIPTION
- Use HTTPS certfile also to build the TLS chain
- Fix `tags` parsing for both APIv2 and APIv3
- Update sparrow (fixes #119 )