### PR TITLE
MIM-869 Handle APIv2 + APIv3 requests (phoenix controller)

### DIFF
--- a/lib/mongoose_push.ex
+++ b/lib/mongoose_push.ex
@@ -25,6 +25,7 @@ defmodule MongoosePush do
           | :priority
           | :time_to_live
           | :mutable_content
+          | :tags
   @type alert_key :: :title | :body | :tag | :badge | :click_action | :sound
   @type data_key :: atom | String.t()
 

--- a/lib/mongoose_push/api/v2/response_encoder.ex
+++ b/lib/mongoose_push/api/v2/response_encoder.ex
@@ -5,7 +5,7 @@ defmodule MongoosePush.API.V2.ResponseEncoder do
   @behaviour MongoosePush.API
   alias MongoosePush.Service
 
-  @spec to_status(:ok | {:error, Service.error() | {:error, MongoosePush.error()}}) ::
+  @spec to_status(:ok | {:error, Service.error()} | {:error, MongoosePush.error()}) ::
           {non_neg_integer, %{details: atom | String.t()} | nil}
   def to_status(:ok), do: {200, nil}
 

--- a/lib/mongoose_push_web/controllers/api_v2_notification_controller.ex
+++ b/lib/mongoose_push_web/controllers/api_v2_notification_controller.ex
@@ -57,7 +57,8 @@ defmodule MongoosePushWeb.APIv2.NotificationController do
   end
 
   def send(conn = %{body_params: params}, %{device_id: device_id}) do
-    result = MongoosePush.Application.backend_module().push(device_id, params)
+    request = MongoosePushWeb.Protocols.RequestDecoder.decode(params)
+    result = MongoosePush.Application.backend_module().push(device_id, request)
     {status, payload} = MongoosePush.API.V2.ResponseEncoder.to_status(result)
 
     conn

--- a/lib/mongoose_push_web/controllers/api_v2_notification_controller.ex
+++ b/lib/mongoose_push_web/controllers/api_v2_notification_controller.ex
@@ -27,6 +27,7 @@ defmodule MongoosePushWeb.APIv2.NotificationController do
           %OpenApiSpex.Schema{
             oneOf: [
               MongoosePushWeb.Schemas.Request.SendNotification.Deep.AlertNotification,
+              MongoosePushWeb.Schemas.Request.SendNotification.Deep.MixedNotification,
               MongoosePushWeb.Schemas.Request.SendNotification.Deep.SilentNotification
             ],
             additionalProperties: false

--- a/lib/mongoose_push_web/controllers/api_v3_notification_controller.ex
+++ b/lib/mongoose_push_web/controllers/api_v3_notification_controller.ex
@@ -87,7 +87,8 @@ defmodule MongoosePushWeb.APIv3.NotificationController do
   end
 
   def send(conn = %{body_params: params}, %{device_id: device_id}) do
-    result = MongoosePush.Application.backend_module().push(device_id, params)
+    request = MongoosePushWeb.Protocols.RequestDecoder.decode(params)
+    result = MongoosePush.Application.backend_module().push(device_id, request)
     {status, payload} = MongoosePush.API.V3.ResponseEncoder.to_status(result)
 
     conn

--- a/lib/mongoose_push_web/controllers/api_v3_notification_controller.ex
+++ b/lib/mongoose_push_web/controllers/api_v3_notification_controller.ex
@@ -27,6 +27,7 @@ defmodule MongoosePushWeb.APIv3.NotificationController do
           %OpenApiSpex.Schema{
             oneOf: [
               MongoosePushWeb.Schemas.Request.SendNotification.Deep.AlertNotification,
+              MongoosePushWeb.Schemas.Request.SendNotification.Deep.MixedNotification,
               MongoosePushWeb.Schemas.Request.SendNotification.Deep.SilentNotification
             ],
             additionalProperties: false

--- a/lib/mongoose_push_web/protocols/request_decoder_helper.ex
+++ b/lib/mongoose_push_web/protocols/request_decoder_helper.ex
@@ -1,0 +1,22 @@
+defmodule MongoosePushWeb.Protocols.RequestDecoderHelper do
+  def add_optional_fields(push_request, schema) do
+    opt_keys = [:mutable_content, :mode, :priority, :tags, :time_to_live, :topic]
+
+    Enum.reduce(opt_keys, push_request, fn x, acc ->
+      case Map.get(schema, x) do
+        nil -> acc
+        val -> Map.put(acc, x, maybe_parse_to_atom(x, val))
+      end
+    end)
+  end
+
+  def maybe_parse_to_atom(:mode, val), do: parse_mode(val)
+  def maybe_parse_to_atom(:priority, val), do: parse_priority(val)
+  def maybe_parse_to_atom(_key, val), do: val
+
+  defp parse_mode("prod"), do: :prod
+  defp parse_mode("dev"), do: :dev
+
+  defp parse_priority("normal"), do: :normal
+  defp parse_priority("high"), do: :high
+end

--- a/lib/mongoose_push_web/protocols/request_decoder_helper.ex
+++ b/lib/mongoose_push_web/protocols/request_decoder_helper.ex
@@ -10,6 +10,9 @@ defmodule MongoosePushWeb.Protocols.RequestDecoderHelper do
     end)
   end
 
+  def parse_service("apns"), do: :apns
+  def parse_service("fcm"), do: :fcm
+
   def maybe_parse_to_atom(:mode, val), do: parse_mode(val)
   def maybe_parse_to_atom(:priority, val), do: parse_priority(val)
   def maybe_parse_to_atom(_key, val), do: val

--- a/lib/mongoose_push_web/schemas/request/send_notification/deep.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/deep.ex
@@ -4,8 +4,6 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep do
   def base() do
     %{
       properties: %{
-        alert: MongoosePushWeb.Schemas.Request.SendNotification.Deep.Common.Alert,
-        data: MongoosePushWeb.Schemas.Request.SendNotification.Deep.Common.Data,
         service: %Schema{
           type: :string,
           description: "Push notification service",
@@ -44,6 +42,9 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep do
 
   def alert() do
     %{
+      properties: %{
+        alert: MongoosePushWeb.Schemas.Request.SendNotification.Deep.Common.Alert
+      },
       required: [:alert],
       example: %{
         "alert" => %{
@@ -60,6 +61,9 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep do
 
   def data() do
     %{
+      properties: %{
+        data: MongoosePushWeb.Schemas.Request.SendNotification.Deep.Common.Data
+      },
       required: [:data],
       example: %{
         "data" => %{

--- a/lib/mongoose_push_web/schemas/request/send_notification/deep/alert_notification.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/deep/alert_notification.ex
@@ -7,7 +7,7 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.AlertNotificatio
     title: "Request.SendNotification.Deep.AlertNotification",
     description: "In this request alert field is mandatory.",
     type: :object,
-    properties: Deep.base()[:properties],
+    properties: Map.merge(Deep.base()[:properties], Deep.alert()[:properties]),
     required: Deep.base()[:required] ++ Deep.alert()[:required],
     example: Map.merge(Deep.base()[:example], Deep.alert()[:example]),
     additionalProperties: false
@@ -24,7 +24,7 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.AlertNotificatio
     end
 
     defp add_optional_fields(push_request, schema) do
-      opt_keys = [:data, :mutable_content, :mode, :priority, :tags, :time_to_live, :topic]
+      opt_keys = [:mutable_content, :mode, :priority, :tags, :time_to_live, :topic]
 
       Enum.reduce(opt_keys, push_request, fn x, acc ->
         case Map.get(schema, x) do

--- a/lib/mongoose_push_web/schemas/request/send_notification/deep/alert_notification.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/deep/alert_notification.ex
@@ -15,33 +15,15 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.AlertNotificatio
 
   defimpl RequestDecoder,
     for: MongoosePushWeb.Schemas.Request.SendNotification.Deep.AlertNotification do
+    alias MongoosePushWeb.Protocols.RequestDecoderHelper
+
+    @spec decode(%Deep.AlertNotification{}) :: MongoosePush.request()
     def decode(schema) do
       %{
         service: String.to_atom(schema.service),
         alert: RequestDecoder.decode(schema.alert)
       }
-      |> add_optional_fields(schema)
+      |> RequestDecoderHelper.add_optional_fields(schema)
     end
-
-    defp add_optional_fields(push_request, schema) do
-      opt_keys = [:mutable_content, :mode, :priority, :tags, :time_to_live, :topic]
-
-      Enum.reduce(opt_keys, push_request, fn x, acc ->
-        case Map.get(schema, x) do
-          nil -> acc
-          val -> Map.put(acc, x, maybe_parse_to_atom(x, val))
-        end
-      end)
-    end
-
-    defp maybe_parse_to_atom(:mode, val), do: parse_mode(val)
-    defp maybe_parse_to_atom(:priority, val), do: parse_priority(val)
-    defp maybe_parse_to_atom(_key, val), do: val
-
-    defp parse_mode("prod"), do: :prod
-    defp parse_mode("dev"), do: :dev
-
-    defp parse_priority("normal"), do: :normal
-    defp parse_priority("high"), do: :high
   end
 end

--- a/lib/mongoose_push_web/schemas/request/send_notification/deep/alert_notification.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/deep/alert_notification.ex
@@ -20,7 +20,7 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.AlertNotificatio
     @spec decode(%Deep.AlertNotification{}) :: MongoosePush.request()
     def decode(schema) do
       %{
-        service: String.to_atom(schema.service),
+        service: RequestDecoderHelper.parse_service(schema.service),
         alert: RequestDecoder.decode(schema.alert)
       }
       |> RequestDecoderHelper.add_optional_fields(schema)

--- a/lib/mongoose_push_web/schemas/request/send_notification/deep/alert_notification.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/deep/alert_notification.ex
@@ -1,5 +1,6 @@
 defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.AlertNotification do
   require OpenApiSpex
+  alias MongoosePushWeb.Protocols.RequestDecoder
   alias MongoosePushWeb.Schemas.Request.SendNotification.Deep
 
   OpenApiSpex.schema(%{
@@ -11,4 +12,36 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.AlertNotificatio
     example: Map.merge(Deep.base()[:example], Deep.alert()[:example]),
     additionalProperties: false
   })
+
+  defimpl RequestDecoder,
+    for: MongoosePushWeb.Schemas.Request.SendNotification.Deep.AlertNotification do
+    def decode(schema) do
+      %{
+        service: String.to_atom(schema.service),
+        alert: RequestDecoder.decode(schema.alert)
+      }
+      |> add_optional_fields(schema)
+    end
+
+    defp add_optional_fields(push_request, schema) do
+      opt_keys = [:data, :mutable_content, :mode, :priority, :tags, :time_to_live, :topic]
+
+      Enum.reduce(opt_keys, push_request, fn x, acc ->
+        case Map.get(schema, x) do
+          nil -> acc
+          val -> Map.put(acc, x, maybe_parse_to_atom(x, val))
+        end
+      end)
+    end
+
+    defp maybe_parse_to_atom(:mode, val), do: parse_mode(val)
+    defp maybe_parse_to_atom(:priority, val), do: parse_priority(val)
+    defp maybe_parse_to_atom(_key, val), do: val
+
+    defp parse_mode("prod"), do: :prod
+    defp parse_mode("dev"), do: :dev
+
+    defp parse_priority("normal"), do: :normal
+    defp parse_priority("high"), do: :high
+  end
 end

--- a/lib/mongoose_push_web/schemas/request/send_notification/deep/common/alert.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/deep/common/alert.ex
@@ -23,4 +23,20 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.Common.Alert do
     example: Deep.alert()[:example]["alert"],
     additionalProperties: false
   })
+
+  defimpl MongoosePushWeb.Protocols.RequestDecoder,
+    for: MongoosePushWeb.Schemas.Request.SendNotification.Deep.Common.Alert do
+    def decode(schema) do
+      %{
+        body: schema.body,
+        title: schema.title,
+        badge: schema.badge,
+        click_action: schema.click_action,
+        tag: schema.tag,
+        sound: schema.sound
+      }
+      |> Enum.filter(fn {_, v} -> v != nil end)
+      |> Enum.into(%{})
+    end
+  end
 end

--- a/lib/mongoose_push_web/schemas/request/send_notification/deep/mixed_notification.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/deep/mixed_notification.ex
@@ -1,23 +1,30 @@
-defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.SilentNotification do
+defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.MixedNotification do
   require OpenApiSpex
   alias MongoosePushWeb.Protocols.RequestDecoder
   alias MongoosePushWeb.Schemas.Request.SendNotification.Deep
 
   OpenApiSpex.schema(%{
-    title: "Request.SendNotification.Deep.SilentNotification",
-    description: "In this request data field is mandatory.",
+    title: "Request.SendNotification.Deep.MixedNotification",
+    description: "In this request both alert and data fields are mandatory.",
     type: :object,
-    properties: Map.merge(Deep.base()[:properties], Deep.data()[:properties]),
-    required: Deep.base()[:required] ++ Deep.data()[:required],
-    example: Map.merge(Deep.base()[:example], Deep.data()[:example]),
+    properties:
+      Deep.base()[:properties]
+      |> Map.merge(Deep.alert()[:properties])
+      |> Map.merge(Deep.data()[:properties]),
+    required: Deep.base()[:required] ++ Deep.alert()[:required] ++ Deep.data()[:required],
+    example:
+      Deep.base()[:example]
+      |> Map.merge(Deep.alert()[:example])
+      |> Map.merge(Deep.data()[:example]),
     additionalProperties: false
   })
 
   defimpl RequestDecoder,
-    for: MongoosePushWeb.Schemas.Request.SendNotification.Deep.SilentNotification do
+    for: MongoosePushWeb.Schemas.Request.SendNotification.Deep.MixedNotification do
     def decode(schema) do
       %{
         service: String.to_atom(schema.service),
+        alert: RequestDecoder.decode(schema.alert),
         data: schema.data
       }
       |> add_optional_fields(schema)

--- a/lib/mongoose_push_web/schemas/request/send_notification/deep/mixed_notification.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/deep/mixed_notification.ex
@@ -26,7 +26,7 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.MixedNotificatio
     @spec decode(%Deep.MixedNotification{}) :: MongoosePush.request()
     def decode(schema) do
       %{
-        service: String.to_atom(schema.service),
+        service: RequestDecoderHelper.parse_service(schema.service),
         alert: RequestDecoder.decode(schema.alert),
         data: schema.data
       }

--- a/lib/mongoose_push_web/schemas/request/send_notification/deep/mixed_notification.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/deep/mixed_notification.ex
@@ -21,34 +21,16 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.MixedNotificatio
 
   defimpl RequestDecoder,
     for: MongoosePushWeb.Schemas.Request.SendNotification.Deep.MixedNotification do
+    alias MongoosePushWeb.Protocols.RequestDecoderHelper
+
+    @spec decode(%Deep.MixedNotification{}) :: MongoosePush.request()
     def decode(schema) do
       %{
         service: String.to_atom(schema.service),
         alert: RequestDecoder.decode(schema.alert),
         data: schema.data
       }
-      |> add_optional_fields(schema)
+      |> RequestDecoderHelper.add_optional_fields(schema)
     end
-
-    defp add_optional_fields(push_request, schema) do
-      opt_keys = [:mutable_content, :mode, :priority, :tags, :time_to_live, :topic]
-
-      Enum.reduce(opt_keys, push_request, fn x, acc ->
-        case Map.get(schema, x) do
-          nil -> acc
-          val -> Map.put(acc, x, maybe_parse_to_atom(x, val))
-        end
-      end)
-    end
-
-    defp maybe_parse_to_atom(:mode, val), do: parse_mode(val)
-    defp maybe_parse_to_atom(:priority, val), do: parse_priority(val)
-    defp maybe_parse_to_atom(_key, val), do: val
-
-    defp parse_mode("prod"), do: :prod
-    defp parse_mode("dev"), do: :dev
-
-    defp parse_priority("normal"), do: :normal
-    defp parse_priority("high"), do: :high
   end
 end

--- a/lib/mongoose_push_web/schemas/request/send_notification/deep/silent_notification.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/deep/silent_notification.ex
@@ -20,7 +20,7 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.SilentNotificati
     @spec decode(%Deep.SilentNotification{}) :: MongoosePush.request()
     def decode(schema) do
       %{
-        service: String.to_atom(schema.service),
+        service: RequestDecoderHelper.parse_service(schema.service),
         data: schema.data
       }
       |> RequestDecoderHelper.add_optional_fields(schema)

--- a/lib/mongoose_push_web/schemas/request/send_notification/deep/silent_notification.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/deep/silent_notification.ex
@@ -15,33 +15,15 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.SilentNotificati
 
   defimpl RequestDecoder,
     for: MongoosePushWeb.Schemas.Request.SendNotification.Deep.SilentNotification do
+    alias MongoosePushWeb.Protocols.RequestDecoderHelper
+
+    @spec decode(%Deep.SilentNotification{}) :: MongoosePush.request()
     def decode(schema) do
       %{
         service: String.to_atom(schema.service),
         data: schema.data
       }
-      |> add_optional_fields(schema)
+      |> RequestDecoderHelper.add_optional_fields(schema)
     end
-
-    defp add_optional_fields(push_request, schema) do
-      opt_keys = [:mutable_content, :mode, :priority, :tags, :time_to_live, :topic]
-
-      Enum.reduce(opt_keys, push_request, fn x, acc ->
-        case Map.get(schema, x) do
-          nil -> acc
-          val -> Map.put(acc, x, maybe_parse_to_atom(x, val))
-        end
-      end)
-    end
-
-    defp maybe_parse_to_atom(:mode, val), do: parse_mode(val)
-    defp maybe_parse_to_atom(:priority, val), do: parse_priority(val)
-    defp maybe_parse_to_atom(_key, val), do: val
-
-    defp parse_mode("prod"), do: :prod
-    defp parse_mode("dev"), do: :dev
-
-    defp parse_priority("normal"), do: :normal
-    defp parse_priority("high"), do: :high
   end
 end

--- a/lib/mongoose_push_web/schemas/request/send_notification/deep/silent_notification.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/deep/silent_notification.ex
@@ -1,5 +1,6 @@
 defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.SilentNotification do
   require OpenApiSpex
+  alias MongoosePushWeb.Protocols.RequestDecoder
   alias MongoosePushWeb.Schemas.Request.SendNotification.Deep
 
   OpenApiSpex.schema(%{
@@ -11,4 +12,42 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.Deep.SilentNotificati
     example: Map.merge(Deep.base()[:example], Deep.data()[:example]),
     additionalProperties: false
   })
+
+  defimpl RequestDecoder,
+    for: MongoosePushWeb.Schemas.Request.SendNotification.Deep.SilentNotification do
+    def decode(schema) do
+      %{
+        service: String.to_atom(schema.service),
+        data: schema.data
+      }
+      |> add_optional_fields(schema)
+      |> maybe_add_alert(schema)
+    end
+
+    defp add_optional_fields(push_request, schema) do
+      opt_keys = [:mutable_content, :mode, :priority, :tags, :time_to_live, :topic]
+
+      Enum.reduce(opt_keys, push_request, fn x, acc ->
+        case Map.get(schema, x) do
+          nil -> acc
+          val -> Map.put(acc, x, maybe_parse_to_atom(x, val))
+        end
+      end)
+    end
+
+    defp maybe_add_alert(push_request, %{alert: nil} = schema), do: push_request
+
+    defp maybe_add_alert(push_request, schema),
+      do: Map.put(push_request, :alert, RequestDecoder.decode(schema.alert))
+
+    defp maybe_parse_to_atom(:mode, val), do: parse_mode(val)
+    defp maybe_parse_to_atom(:priority, val), do: parse_priority(val)
+    defp maybe_parse_to_atom(_key, val), do: val
+
+    defp parse_mode("prod"), do: :prod
+    defp parse_mode("dev"), do: :dev
+
+    defp parse_priority("normal"), do: :normal
+    defp parse_priority("high"), do: :high
+  end
 end

--- a/lib/mongoose_push_web/schemas/request/send_notification/flat_notification.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/flat_notification.ex
@@ -49,6 +49,8 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.FlatNotification do
 
   defimpl MongoosePushWeb.Protocols.RequestDecoder,
     for: Request.SendNotification.FlatNotification do
+    alias MongoosePushWeb.Protocols.RequestDecoderHelper
+
     @spec decode(%Request.SendNotification.FlatNotification{}) :: MongoosePush.request()
     def decode(schema) do
       %{
@@ -68,7 +70,7 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.FlatNotification do
       Enum.reduce(opt_keys, push_request, fn x, acc ->
         case Map.get(schema, x) do
           nil -> acc
-          val -> Map.put(acc, x, maybe_parse_to_atom(x, val))
+          val -> Map.put(acc, x, RequestDecoderHelper.maybe_parse_to_atom(x, val))
         end
       end)
     end
@@ -83,11 +85,5 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.FlatNotification do
         end
       end)
     end
-
-    defp maybe_parse_to_atom(:mode, val), do: parse_mode(val)
-    defp maybe_parse_to_atom(_key, val), do: val
-
-    defp parse_mode("prod"), do: :prod
-    defp parse_mode("dev"), do: :dev
   end
 end

--- a/lib/mongoose_push_web/schemas/request/send_notification/flat_notification.ex
+++ b/lib/mongoose_push_web/schemas/request/send_notification/flat_notification.ex
@@ -54,7 +54,7 @@ defmodule MongoosePushWeb.Schemas.Request.SendNotification.FlatNotification do
     @spec decode(%Request.SendNotification.FlatNotification{}) :: MongoosePush.request()
     def decode(schema) do
       %{
-        service: String.to_atom(schema.service),
+        service: RequestDecoderHelper.parse_service(schema.service),
         alert: %{
           body: schema.body,
           title: schema.title

--- a/test/mongoose_push_web/controllers/api_v2_notification_controller_test.exs
+++ b/test/mongoose_push_web/controllers/api_v2_notification_controller_test.exs
@@ -202,7 +202,7 @@ defmodule MongoosePushWeb.APIv2NotificationControllerTest do
 
   # decoder end-to-end tests
 
-  test "AlertNotification/SilentNotification decoder test: all possible fields", %{conn: conn} do
+  test "AlertNotification decoder test: all possible fields", %{conn: conn} do
     device_id = "1"
     expected_device_id = "1"
 
@@ -221,8 +221,7 @@ defmodule MongoosePushWeb.APIv2NotificationControllerTest do
         "click_action" => ".SomeApp.Handler.action",
         "tag" => "info",
         "sound" => "standard.mp3"
-      },
-      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+      }
     }
 
     expected_request = %{
@@ -234,7 +233,6 @@ defmodule MongoosePushWeb.APIv2NotificationControllerTest do
         tag: "info",
         title: "Notification title"
       },
-      data: %{"acme1" => "value1", "acme2" => "value2"},
       mode: :prod,
       service: :apns,
       topic: "com.someapp",
@@ -310,8 +308,7 @@ defmodule MongoosePushWeb.APIv2NotificationControllerTest do
         "title" => "Notification title",
         "tag" => "info",
         "sound" => "standard.mp3"
-      },
-      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+      }
     }
 
     expected_request = %{
@@ -321,7 +318,7 @@ defmodule MongoosePushWeb.APIv2NotificationControllerTest do
         tag: "info",
         title: "Notification title"
       },
-      service: :apns,
+      service: :fcm,
       mutable_content: false
     }
 
@@ -439,29 +436,30 @@ defmodule MongoosePushWeb.APIv2NotificationControllerTest do
     post_and_assert(conn, device_id, expected_device_id, request, expected_request)
   end
 
-  test "AlertNotification decoder test: data + alert.badge field", %{conn: conn} do
+  test "SilentNotification decoder test: all possible fields", %{conn: conn} do
     device_id = "9"
     expected_device_id = "9"
 
     request = %{
       "service" => "apns",
-      "alert" => %{
-        "body" => "A message from someone",
-        "title" => "Notification title",
-        "badge" => 7
-      },
+      "mode" => "prod",
+      "priority" => "normal",
+      "time_to_live" => 3600,
+      "mutable_content" => false,
+      "tags" => ["some", "tags", "for", "pool", "selection"],
+      "topic" => "com.someapp",
       "data" => %{"acme1" => "value1", "acme2" => "value2"}
     }
 
     expected_request = %{
-      alert: %{
-        badge: 7,
-        body: "A message from someone",
-        title: "Notification title"
-      },
       data: %{"acme1" => "value1", "acme2" => "value2"},
+      mode: :prod,
       service: :apns,
-      mutable_content: false
+      topic: "com.someapp",
+      priority: :normal,
+      time_to_live: 3600,
+      mutable_content: false,
+      tags: ["some", "tags", "for", "pool", "selection"]
     }
 
     post_and_assert(conn, device_id, expected_device_id, request, expected_request)
@@ -565,6 +563,264 @@ defmodule MongoosePushWeb.APIv2NotificationControllerTest do
       mode: :dev,
       service: :apns,
       data: %{"acme1" => "value1", "acme2" => "value2"},
+      priority: :normal,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: all possible fields", %{conn: conn} do
+    device_id = "15"
+    expected_device_id = "15"
+
+    request = %{
+      "service" => "fcm",
+      "mode" => "prod",
+      "priority" => "normal",
+      "time_to_live" => 3600,
+      "mutable_content" => false,
+      "tags" => ["some", "tags", "for", "pool", "selection"],
+      "topic" => "com.someapp",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "badge" => 7,
+        "click_action" => ".SomeApp.Handler.action",
+        "tag" => "info",
+        "sound" => "standard.mp3"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        badge: 7,
+        body: "A message from someone",
+        click_action: ".SomeApp.Handler.action",
+        sound: "standard.mp3",
+        tag: "info",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      mode: :prod,
+      service: :fcm,
+      topic: "com.someapp",
+      priority: :normal,
+      time_to_live: 3600,
+      mutable_content: false,
+      tags: ["some", "tags", "for", "pool", "selection"]
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: all required fields", %{conn: conn} do
+    device_id = "16"
+    expected_device_id = "16"
+
+    request = %{
+      "service" => "apns",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "badge" => 7,
+        "click_action" => ".SomeApp.Handler.action",
+        "tag" => "info",
+        "sound" => "standard.mp3"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        badge: 7,
+        body: "A message from someone",
+        click_action: ".SomeApp.Handler.action",
+        sound: "standard.mp3",
+        tag: "info",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      service: :apns,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: alert.badge + alert.click_action fields", %{conn: conn} do
+    device_id = "17"
+    expected_device_id = "17"
+
+    request = %{
+      "service" => "fcm",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "badge" => 7,
+        "click_action" => ".SomeApp.Handler.action"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        badge: 7,
+        body: "A message from someone",
+        click_action: ".SomeApp.Handler.action",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      service: :fcm,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: alert.tag + alert.sound fields", %{conn: conn} do
+    device_id = "18"
+    expected_device_id = "18"
+
+    request = %{
+      "service" => "apns",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "tag" => "info",
+        "sound" => "standard.mp3"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        sound: "standard.mp3",
+        tag: "info",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      service: :apns,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: time_to_live + mutable_content fields", %{conn: conn} do
+    device_id = "19"
+    expected_device_id = "19"
+
+    request = %{
+      "service" => "fcm",
+      "time_to_live" => 3600,
+      "mutable_content" => true,
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      service: :fcm,
+      time_to_live: 3600,
+      mutable_content: true
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: tags + topic fields", %{conn: conn} do
+    device_id = "20"
+    expected_device_id = "20"
+
+    request = %{
+      "service" => "apns",
+      "tags" => ["some", "tags", "for", "pool", "selection"],
+      "topic" => "com.someapp",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      service: :apns,
+      topic: "com.someapp",
+      mutable_content: false,
+      tags: ["some", "tags", "for", "pool", "selection"]
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: mode :prod + priority :high fields", %{conn: conn} do
+    device_id = "21"
+    expected_device_id = "21"
+
+    request = %{
+      "service" => "fcm",
+      "mode" => "prod",
+      "priority" => "high",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      mode: :prod,
+      service: :fcm,
+      priority: :high,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: mode :dev + priority :normal fields", %{conn: conn} do
+    device_id = "22"
+    expected_device_id = "22"
+
+    request = %{
+      "service" => "apns",
+      "mode" => "dev",
+      "priority" => "normal",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      mode: :dev,
+      service: :apns,
       priority: :normal,
       mutable_content: false
     }

--- a/test/mongoose_push_web/controllers/api_v2_notification_controller_test.exs
+++ b/test/mongoose_push_web/controllers/api_v2_notification_controller_test.exs
@@ -134,4 +134,464 @@ defmodule MongoosePushWeb.APIv2NotificationControllerTest do
 
     assert json_response(conn, 422) == ControllersHelper.no_schemas_provided_response()
   end
+
+  # Service.error() errors
+
+  test "invalid request error", %{conn: conn} do
+    post_and_assert_error_500(conn, :invalid_request, :BadCollapseId)
+  end
+
+  test "internal config error", %{conn: conn} do
+    post_and_assert_error_500(conn, :internal_config, :BadMessageId)
+  end
+
+  test "auth error", %{conn: conn} do
+    post_and_assert_error_500(conn, :auth, :MissingProviderToken)
+  end
+
+  test "unregistered error", %{conn: conn} do
+    post_and_assert_error_500(conn, :unregistered, :Unregistered)
+  end
+
+  test "too many requests error", %{conn: conn} do
+    post_and_assert_error_500(conn, :too_many_requests, :TooManyRequests)
+  end
+
+  test "unspecified error", %{conn: conn} do
+    post_and_assert_error_500(conn, :unspecified, :Unspecified)
+  end
+
+  test "service internal error", %{conn: conn} do
+    post_and_assert_error_500(conn, :service_internal, :InternalServerError)
+  end
+
+  test "payload too large error", %{conn: conn} do
+    post_and_assert_error_500(conn, :payload_too_large, :PayloadTooLarge)
+  end
+
+  test "unknown error", %{conn: conn} do
+    post_and_assert_error_500(conn, :unknown, :Unknown)
+  end
+
+  # MongoosePush.error() errors
+
+  test "generic no matching pool error", %{conn: conn} do
+    post_and_assert_error_500(conn, :generic, :no_matching_pool)
+  end
+
+  test "generic connection lost error", %{conn: conn} do
+    post_and_assert_error_500(conn, :generic, :connection_lost)
+  end
+
+  test "generic invalid notification error", %{conn: conn} do
+    post_and_assert_error_500(conn, :generic, :invalid_notification)
+  end
+
+  test "generic unable to connect error", %{conn: conn} do
+    device_id = "666"
+    request = ControllersHelper.flat_request()
+
+    expect(MongoosePush.Notification.MockImpl, :push, fn _device_id, _request ->
+      {:error, {:generic, :unable_to_connect}}
+    end)
+
+    conn = post(conn, "/v1/notification/#{device_id}", Jason.encode!(request))
+
+    assert json_response(conn, 503) == %{"details" => "Please try again later"}
+  end
+
+  # decoder end-to-end tests
+
+  test "AlertNotification/SilentNotification decoder test: all possible fields", %{conn: conn} do
+    device_id = "1"
+    expected_device_id = "1"
+
+    request = %{
+      "service" => "apns",
+      "mode" => "prod",
+      "priority" => "normal",
+      "time_to_live" => 3600,
+      "mutable_content" => false,
+      "tags" => ["some", "tags", "for", "pool", "selection"],
+      "topic" => "com.someapp",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "badge" => 7,
+        "click_action" => ".SomeApp.Handler.action",
+        "tag" => "info",
+        "sound" => "standard.mp3"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        badge: 7,
+        body: "A message from someone",
+        click_action: ".SomeApp.Handler.action",
+        sound: "standard.mp3",
+        tag: "info",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      mode: :prod,
+      service: :apns,
+      topic: "com.someapp",
+      priority: :normal,
+      time_to_live: 3600,
+      mutable_content: false,
+      tags: ["some", "tags", "for", "pool", "selection"]
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: all required fields", %{conn: conn} do
+    device_id = "2"
+    expected_device_id = "2"
+
+    request = %{
+      "service" => "fcm",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      }
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      service: :fcm,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: alert.badge + alert.click_action fields", %{conn: conn} do
+    device_id = "3"
+    expected_device_id = "3"
+
+    request = %{
+      "service" => "apns",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "badge" => 7,
+        "click_action" => ".SomeApp.Handler.action"
+      }
+    }
+
+    expected_request = %{
+      alert: %{
+        badge: 7,
+        body: "A message from someone",
+        click_action: ".SomeApp.Handler.action",
+        title: "Notification title"
+      },
+      service: :apns,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: alert.tag + alert.sound fields", %{conn: conn} do
+    device_id = "4"
+    expected_device_id = "4"
+
+    request = %{
+      "service" => "fcm",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "tag" => "info",
+        "sound" => "standard.mp3"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        sound: "standard.mp3",
+        tag: "info",
+        title: "Notification title"
+      },
+      service: :apns,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: time_to_live + mutable_content fields", %{conn: conn} do
+    device_id = "5"
+    expected_device_id = "5"
+
+    request = %{
+      "service" => "apns",
+      "time_to_live" => 3600,
+      "mutable_content" => true,
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      }
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      service: :apns,
+      time_to_live: 3600,
+      mutable_content: true
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: tags + topic fields", %{conn: conn} do
+    device_id = "6"
+    expected_device_id = "6"
+
+    request = %{
+      "service" => "apns",
+      "tags" => ["some", "tags", "for", "pool", "selection"],
+      "topic" => "com.someapp",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      }
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      service: :apns,
+      topic: "com.someapp",
+      mutable_content: false,
+      tags: ["some", "tags", "for", "pool", "selection"]
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: mode :prod + priority :high fields", %{conn: conn} do
+    device_id = "7"
+    expected_device_id = "7"
+
+    request = %{
+      "service" => "fcm",
+      "mode" => "prod",
+      "priority" => "high",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      }
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      mode: :prod,
+      service: :fcm,
+      priority: :high,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: mode :dev + priority :normal fields", %{conn: conn} do
+    device_id = "8"
+    expected_device_id = "8"
+
+    request = %{
+      "service" => "apns",
+      "mode" => "dev",
+      "priority" => "normal",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      }
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      mode: :dev,
+      service: :apns,
+      priority: :normal,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: data + alert.badge field", %{conn: conn} do
+    device_id = "9"
+    expected_device_id = "9"
+
+    request = %{
+      "service" => "apns",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "badge" => 7
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        badge: 7,
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      service: :apns,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "SilentNotification decoder test: all required fields", %{conn: conn} do
+    device_id = "10"
+    expected_device_id = "10"
+
+    request = %{
+      "service" => "apns",
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      service: :apns,
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "SilentNotification decoder test: time_to_live + mutable_content fields", %{conn: conn} do
+    device_id = "11"
+    expected_device_id = "11"
+
+    request = %{
+      "service" => "apns",
+      "data" => %{"acme1" => "value1", "acme2" => "value2"},
+      "time_to_live" => 3600,
+      "mutable_content" => true
+    }
+
+    expected_request = %{
+      service: :apns,
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      time_to_live: 3600,
+      mutable_content: true
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "SilentNotification decoder test: tags + topic fields", %{conn: conn} do
+    device_id = "12"
+    expected_device_id = "12"
+
+    request = %{
+      "service" => "apns",
+      "data" => %{"acme1" => "value1", "acme2" => "value2"},
+      "tags" => ["some", "tags", "for", "pool", "selection"],
+      "topic" => "com.someapp"
+    }
+
+    expected_request = %{
+      service: :apns,
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      topic: "com.someapp",
+      mutable_content: false,
+      tags: ["some", "tags", "for", "pool", "selection"]
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "SilentNotification decoder test: mode :prod + priority :high fields", %{conn: conn} do
+    device_id = "13"
+    expected_device_id = "13"
+
+    request = %{
+      "service" => "fcm",
+      "data" => %{"acme1" => "value1", "acme2" => "value2"},
+      "mode" => "prod",
+      "priority" => "high"
+    }
+
+    expected_request = %{
+      mode: :prod,
+      service: :fcm,
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      priority: :high,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "SilentNotification decoder test: mode :dev + priority :normal fields", %{conn: conn} do
+    device_id = "14"
+    expected_device_id = "14"
+
+    request = %{
+      "service" => "apns",
+      "data" => %{"acme1" => "value1", "acme2" => "value2"},
+      "mode" => "dev",
+      "priority" => "normal"
+    }
+
+    expected_request = %{
+      mode: :dev,
+      service: :apns,
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      priority: :normal,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  defp post_and_assert_error_500(conn, type, reason) do
+    device_id = "666"
+    request = ControllersHelper.alert_request()
+
+    expect(MongoosePush.Notification.MockImpl, :push, fn _device_id, _request ->
+      {:error, {type, reason}}
+    end)
+
+    conn = post(conn, "/v2/notification/#{device_id}", Jason.encode!(request))
+
+    assert json_response(conn, 500) == %{"details" => to_string(reason)}
+  end
+
+  defp post_and_assert(conn, device_id, expected_device_id, request, expected_request) do
+    expect(MongoosePush.Notification.MockImpl, :push, fn device_id, request ->
+      assert request == expected_request
+      assert device_id == expected_device_id
+      :ok
+    end)
+
+    post(conn, "/v2/notification/#{device_id}", Jason.encode!(request))
+  end
 end

--- a/test/mongoose_push_web/controllers/api_v3_notification_controller_test.exs
+++ b/test/mongoose_push_web/controllers/api_v3_notification_controller_test.exs
@@ -134,4 +134,455 @@ defmodule MongoosePushWeb.APIv3NotificationControllerTest do
 
     assert json_response(conn, 422) == ControllersHelper.no_schemas_provided_response()
   end
+
+  # Service.error() errors
+
+  test "invalid request error", %{conn: conn} do
+    post_and_assert_error(conn, 400, {:invalid_request, :BadCollapseId}, :invalid_request)
+  end
+
+  test "unregistered error", %{conn: conn} do
+    post_and_assert_error(conn, 410, {:unregistered, :Unregistered}, :unregistered)
+  end
+
+  test "payload too large error", %{conn: conn} do
+    post_and_assert_error(conn, 413, {:payload_too_large, :PayloadTooLarge}, :payload_too_large)
+  end
+
+  test "too many requests error", %{conn: conn} do
+    post_and_assert_error(conn, 429, {:too_many_requests, :TooManyRequests}, :too_many_requests)
+  end
+
+  test "service internal error", %{conn: conn} do
+    post_and_assert_error(conn, 503, {:service_internal, :ServiceUnavailable}, :service_internal)
+  end
+
+  test "auth error", %{conn: conn} do
+    post_and_assert_error(conn, 503, {:auth, :BadCertificate}, :service_internal)
+  end
+
+  test "internal config error", %{conn: conn} do
+    post_and_assert_error(conn, 503, {:internal_config, :DuplicateHeaders}, :internal_config)
+  end
+
+  test "unspecified error", %{conn: conn} do
+    post_and_assert_error(conn, 520, {:unspecified, :Unspecified}, :unspecified)
+  end
+
+  # MongoosePush.error() errors
+
+  test "generic no matching pool error", %{conn: conn} do
+    post_and_assert_error(conn, 400, {:generic, :no_matching_pool}, :no_matching_pool)
+  end
+
+  test "generic unable to connect error", %{conn: conn} do
+    post_and_assert_error(conn, 503, {:generic, :unable_to_connect}, :unable_to_connect)
+  end
+
+  test "generic connection lost error", %{conn: conn} do
+    post_and_assert_error(conn, 503, {:generic, :connection_lost}, :connection_lost)
+  end
+
+  test "generic invalid notification error", %{conn: conn} do
+    post_and_assert_error(conn, 400, {:generic, :invalid_notification}, :invalid_notification)
+  end
+
+  test "generic unspecified error", %{conn: conn} do
+    post_and_assert_error(conn, 500, {:generic, :unspecified}, :unspecified)
+  end
+
+  # decoder end-to-end tests
+
+  test "AlertNotification/SilentNotification decoder test: all possible fields", %{conn: conn} do
+    device_id = "1"
+    expected_device_id = "1"
+
+    request = %{
+      "service" => "apns",
+      "mode" => "prod",
+      "priority" => "normal",
+      "time_to_live" => 3600,
+      "mutable_content" => false,
+      "tags" => ["some", "tags", "for", "pool", "selection"],
+      "topic" => "com.someapp",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "badge" => 7,
+        "click_action" => ".SomeApp.Handler.action",
+        "tag" => "info",
+        "sound" => "standard.mp3"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        badge: 7,
+        body: "A message from someone",
+        click_action: ".SomeApp.Handler.action",
+        sound: "standard.mp3",
+        tag: "info",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      mode: :prod,
+      service: :apns,
+      topic: "com.someapp",
+      priority: :normal,
+      time_to_live: 3600,
+      mutable_content: false,
+      tags: ["some", "tags", "for", "pool", "selection"]
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: all required fields", %{conn: conn} do
+    device_id = "2"
+    expected_device_id = "2"
+
+    request = %{
+      "service" => "fcm",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      }
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      service: :fcm,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: alert.badge + alert.click_action fields", %{conn: conn} do
+    device_id = "3"
+    expected_device_id = "3"
+
+    request = %{
+      "service" => "apns",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "badge" => 7,
+        "click_action" => ".SomeApp.Handler.action"
+      }
+    }
+
+    expected_request = %{
+      alert: %{
+        badge: 7,
+        body: "A message from someone",
+        click_action: ".SomeApp.Handler.action",
+        title: "Notification title"
+      },
+      service: :apns,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: alert.tag + alert.sound fields", %{conn: conn} do
+    device_id = "4"
+    expected_device_id = "4"
+
+    request = %{
+      "service" => "fcm",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "tag" => "info",
+        "sound" => "standard.mp3"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        sound: "standard.mp3",
+        tag: "info",
+        title: "Notification title"
+      },
+      service: :apns,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: time_to_live + mutable_content fields", %{conn: conn} do
+    device_id = "5"
+    expected_device_id = "5"
+
+    request = %{
+      "service" => "apns",
+      "time_to_live" => 3600,
+      "mutable_content" => true,
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      }
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      service: :apns,
+      time_to_live: 3600,
+      mutable_content: true
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: tags + topic fields", %{conn: conn} do
+    device_id = "6"
+    expected_device_id = "6"
+
+    request = %{
+      "service" => "apns",
+      "tags" => ["some", "tags", "for", "pool", "selection"],
+      "topic" => "com.someapp",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      }
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      service: :apns,
+      topic: "com.someapp",
+      mutable_content: false,
+      tags: ["some", "tags", "for", "pool", "selection"]
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: mode :prod + priority :high fields", %{conn: conn} do
+    device_id = "7"
+    expected_device_id = "7"
+
+    request = %{
+      "service" => "fcm",
+      "mode" => "prod",
+      "priority" => "high",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      }
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      mode: :prod,
+      service: :fcm,
+      priority: :high,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: mode :dev + priority :normal fields", %{conn: conn} do
+    device_id = "8"
+    expected_device_id = "8"
+
+    request = %{
+      "service" => "apns",
+      "mode" => "dev",
+      "priority" => "normal",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      }
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      mode: :dev,
+      service: :apns,
+      priority: :normal,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "AlertNotification decoder test: data + alert.badge field", %{conn: conn} do
+    device_id = "9"
+    expected_device_id = "9"
+
+    request = %{
+      "service" => "apns",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "badge" => 7
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        badge: 7,
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      service: :apns,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "SilentNotification decoder test: all required fields", %{conn: conn} do
+    device_id = "10"
+    expected_device_id = "10"
+
+    request = %{
+      "service" => "apns",
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      service: :apns,
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "SilentNotification decoder test: time_to_live + mutable_content fields", %{conn: conn} do
+    device_id = "11"
+    expected_device_id = "11"
+
+    request = %{
+      "service" => "apns",
+      "data" => %{"acme1" => "value1", "acme2" => "value2"},
+      "time_to_live" => 3600,
+      "mutable_content" => true
+    }
+
+    expected_request = %{
+      service: :apns,
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      time_to_live: 3600,
+      mutable_content: true
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "SilentNotification decoder test: tags + topic fields", %{conn: conn} do
+    device_id = "12"
+    expected_device_id = "12"
+
+    request = %{
+      "service" => "apns",
+      "data" => %{"acme1" => "value1", "acme2" => "value2"},
+      "tags" => ["some", "tags", "for", "pool", "selection"],
+      "topic" => "com.someapp"
+    }
+
+    expected_request = %{
+      service: :apns,
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      topic: "com.someapp",
+      mutable_content: false,
+      tags: ["some", "tags", "for", "pool", "selection"]
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "SilentNotification decoder test: mode :prod + priority :high fields", %{conn: conn} do
+    device_id = "13"
+    expected_device_id = "13"
+
+    request = %{
+      "service" => "fcm",
+      "data" => %{"acme1" => "value1", "acme2" => "value2"},
+      "mode" => "prod",
+      "priority" => "high"
+    }
+
+    expected_request = %{
+      mode: :prod,
+      service: :fcm,
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      priority: :high,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "SilentNotification decoder test: mode :dev + priority :normal fields", %{conn: conn} do
+    device_id = "14"
+    expected_device_id = "14"
+
+    request = %{
+      "service" => "apns",
+      "data" => %{"acme1" => "value1", "acme2" => "value2"},
+      "mode" => "dev",
+      "priority" => "normal"
+    }
+
+    expected_request = %{
+      mode: :dev,
+      service: :apns,
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      priority: :normal,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  defp post_and_assert(conn, device_id, expected_device_id, request, expected_request) do
+    expect(MongoosePush.Notification.MockImpl, :push, fn device_id, request ->
+      assert request == expected_request
+      assert device_id == expected_device_id
+      :ok
+    end)
+
+    post(conn, "/v3/notification/#{device_id}", Jason.encode!(request))
+  end
+
+  defp post_and_assert_error(conn, number, {type, reason}, error_reason) do
+    device_id = "666"
+    request = ControllersHelper.alert_request()
+
+    expect(MongoosePush.Notification.MockImpl, :push, fn _device_id, _request ->
+      {:error, {type, reason}}
+    end)
+
+    conn = post(conn, "/v3/notification/#{device_id}", Jason.encode!(request))
+
+    assert json_response(conn, number) == %{"reason" => to_string(error_reason)}
+  end
 end

--- a/test/mongoose_push_web/controllers/api_v3_notification_controller_test.exs
+++ b/test/mongoose_push_web/controllers/api_v3_notification_controller_test.exs
@@ -193,7 +193,7 @@ defmodule MongoosePushWeb.APIv3NotificationControllerTest do
 
   # decoder end-to-end tests
 
-  test "AlertNotification/SilentNotification decoder test: all possible fields", %{conn: conn} do
+  test "AlertNotification decoder test: all possible fields", %{conn: conn} do
     device_id = "1"
     expected_device_id = "1"
 
@@ -212,8 +212,7 @@ defmodule MongoosePushWeb.APIv3NotificationControllerTest do
         "click_action" => ".SomeApp.Handler.action",
         "tag" => "info",
         "sound" => "standard.mp3"
-      },
-      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+      }
     }
 
     expected_request = %{
@@ -225,7 +224,6 @@ defmodule MongoosePushWeb.APIv3NotificationControllerTest do
         tag: "info",
         title: "Notification title"
       },
-      data: %{"acme1" => "value1", "acme2" => "value2"},
       mode: :prod,
       service: :apns,
       topic: "com.someapp",
@@ -301,8 +299,7 @@ defmodule MongoosePushWeb.APIv3NotificationControllerTest do
         "title" => "Notification title",
         "tag" => "info",
         "sound" => "standard.mp3"
-      },
-      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+      }
     }
 
     expected_request = %{
@@ -312,7 +309,7 @@ defmodule MongoosePushWeb.APIv3NotificationControllerTest do
         tag: "info",
         title: "Notification title"
       },
-      service: :apns,
+      service: :fcm,
       mutable_content: false
     }
 
@@ -430,29 +427,30 @@ defmodule MongoosePushWeb.APIv3NotificationControllerTest do
     post_and_assert(conn, device_id, expected_device_id, request, expected_request)
   end
 
-  test "AlertNotification decoder test: data + alert.badge field", %{conn: conn} do
+  test "SilentNotification decoder test: all possible fields", %{conn: conn} do
     device_id = "9"
     expected_device_id = "9"
 
     request = %{
       "service" => "apns",
-      "alert" => %{
-        "body" => "A message from someone",
-        "title" => "Notification title",
-        "badge" => 7
-      },
+      "mode" => "prod",
+      "priority" => "normal",
+      "time_to_live" => 3600,
+      "mutable_content" => false,
+      "tags" => ["some", "tags", "for", "pool", "selection"],
+      "topic" => "com.someapp",
       "data" => %{"acme1" => "value1", "acme2" => "value2"}
     }
 
     expected_request = %{
-      alert: %{
-        badge: 7,
-        body: "A message from someone",
-        title: "Notification title"
-      },
       data: %{"acme1" => "value1", "acme2" => "value2"},
+      mode: :prod,
       service: :apns,
-      mutable_content: false
+      topic: "com.someapp",
+      priority: :normal,
+      time_to_live: 3600,
+      mutable_content: false,
+      tags: ["some", "tags", "for", "pool", "selection"]
     }
 
     post_and_assert(conn, device_id, expected_device_id, request, expected_request)
@@ -556,6 +554,264 @@ defmodule MongoosePushWeb.APIv3NotificationControllerTest do
       mode: :dev,
       service: :apns,
       data: %{"acme1" => "value1", "acme2" => "value2"},
+      priority: :normal,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: all possible fields", %{conn: conn} do
+    device_id = "15"
+    expected_device_id = "15"
+
+    request = %{
+      "service" => "fcm",
+      "mode" => "prod",
+      "priority" => "normal",
+      "time_to_live" => 3600,
+      "mutable_content" => false,
+      "tags" => ["some", "tags", "for", "pool", "selection"],
+      "topic" => "com.someapp",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "badge" => 7,
+        "click_action" => ".SomeApp.Handler.action",
+        "tag" => "info",
+        "sound" => "standard.mp3"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        badge: 7,
+        body: "A message from someone",
+        click_action: ".SomeApp.Handler.action",
+        sound: "standard.mp3",
+        tag: "info",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      mode: :prod,
+      service: :fcm,
+      topic: "com.someapp",
+      priority: :normal,
+      time_to_live: 3600,
+      mutable_content: false,
+      tags: ["some", "tags", "for", "pool", "selection"]
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: all required fields", %{conn: conn} do
+    device_id = "16"
+    expected_device_id = "16"
+
+    request = %{
+      "service" => "apns",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "badge" => 7,
+        "click_action" => ".SomeApp.Handler.action",
+        "tag" => "info",
+        "sound" => "standard.mp3"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        badge: 7,
+        body: "A message from someone",
+        click_action: ".SomeApp.Handler.action",
+        sound: "standard.mp3",
+        tag: "info",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      service: :apns,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: alert.badge + alert.click_action fields", %{conn: conn} do
+    device_id = "17"
+    expected_device_id = "17"
+
+    request = %{
+      "service" => "fcm",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "badge" => 7,
+        "click_action" => ".SomeApp.Handler.action"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        badge: 7,
+        body: "A message from someone",
+        click_action: ".SomeApp.Handler.action",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      service: :fcm,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: alert.tag + alert.sound fields", %{conn: conn} do
+    device_id = "18"
+    expected_device_id = "18"
+
+    request = %{
+      "service" => "apns",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title",
+        "tag" => "info",
+        "sound" => "standard.mp3"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        sound: "standard.mp3",
+        tag: "info",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      service: :apns,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: time_to_live + mutable_content fields", %{conn: conn} do
+    device_id = "19"
+    expected_device_id = "19"
+
+    request = %{
+      "service" => "fcm",
+      "time_to_live" => 3600,
+      "mutable_content" => true,
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      service: :fcm,
+      time_to_live: 3600,
+      mutable_content: true
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: tags + topic fields", %{conn: conn} do
+    device_id = "20"
+    expected_device_id = "20"
+
+    request = %{
+      "service" => "apns",
+      "tags" => ["some", "tags", "for", "pool", "selection"],
+      "topic" => "com.someapp",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      service: :apns,
+      topic: "com.someapp",
+      mutable_content: false,
+      tags: ["some", "tags", "for", "pool", "selection"]
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: mode :prod + priority :high fields", %{conn: conn} do
+    device_id = "21"
+    expected_device_id = "21"
+
+    request = %{
+      "service" => "fcm",
+      "mode" => "prod",
+      "priority" => "high",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      mode: :prod,
+      service: :fcm,
+      priority: :high,
+      mutable_content: false
+    }
+
+    post_and_assert(conn, device_id, expected_device_id, request, expected_request)
+  end
+
+  test "MixedNotification decoder test: mode :dev + priority :normal fields", %{conn: conn} do
+    device_id = "22"
+    expected_device_id = "22"
+
+    request = %{
+      "service" => "apns",
+      "mode" => "dev",
+      "priority" => "normal",
+      "alert" => %{
+        "body" => "A message from someone",
+        "title" => "Notification title"
+      },
+      "data" => %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected_request = %{
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      mode: :dev,
+      service: :apns,
       priority: :normal,
       mutable_content: false
     }

--- a/test/unit/request_decoder_test.exs
+++ b/test/unit/request_decoder_test.exs
@@ -1,10 +1,13 @@
 defmodule RequestDecoderTest do
   use ExUnit.Case, async: false
   alias MongoosePushWeb.Protocols.RequestDecoder
-  alias MongoosePushWeb.Schemas.Request
+  alias MongoosePushWeb.Schemas.Request.SendNotification.Deep.AlertNotification
+  alias MongoosePushWeb.Schemas.Request.SendNotification.Deep.SilentNotification
+  alias MongoosePushWeb.Schemas.Request.SendNotification.Deep.Common.Alert
+  alias MongoosePushWeb.Schemas.Request.SendNotification.FlatNotification
 
-  test "decoder does well with all-fields schema" do
-    input = %Request.SendNotification.FlatNotification{
+  test "FlatNotification: decoder does well with all-fields schema" do
+    input = %FlatNotification{
       badge: 7,
       body: "A message from someone",
       click_action: ".SomeApp.Handler.action",
@@ -33,8 +36,8 @@ defmodule RequestDecoderTest do
     assert expected == RequestDecoder.decode(input)
   end
 
-  test "decoder does not fail without optional alert fields" do
-    input = %Request.SendNotification.FlatNotification{
+  test "FlatNotification: decoder does not fail without optional alert fields" do
+    input = %FlatNotification{
       body: "A message from someone",
       service: "apns",
       title: "Notification title",
@@ -57,8 +60,8 @@ defmodule RequestDecoderTest do
     assert expected == RequestDecoder.decode(input)
   end
 
-  test "decoder does not fail without optional fields at all" do
-    input = %Request.SendNotification.FlatNotification{
+  test "FlatNotification: decoder does not fail without optional fields at all" do
+    input = %FlatNotification{
       body: "A message from someone",
       service: "apns",
       title: "Notification title"
@@ -70,6 +73,204 @@ defmodule RequestDecoderTest do
         body: "A message from someone",
         title: "Notification title"
       }
+    }
+
+    assert expected == RequestDecoder.decode(input)
+  end
+
+  # Alert
+
+  test "Alert: minimum fields schema" do
+    input = %Alert{
+      body: "A message from someone",
+      title: "Notification title"
+    }
+
+    expected = %{
+      body: "A message from someone",
+      title: "Notification title"
+    }
+
+    assert expected == RequestDecoder.decode(input)
+  end
+
+  test "Alert: all-fields schema" do
+    input = %Alert{
+      body: "A message from someone",
+      title: "Notification title",
+      badge: 7,
+      click_action: ".SomeApp.Handler.action",
+      tag: "info",
+      sound: "standard.mp3"
+    }
+
+    expected = %{
+      body: "A message from someone",
+      title: "Notification title",
+      badge: 7,
+      click_action: ".SomeApp.Handler.action",
+      tag: "info",
+      sound: "standard.mp3"
+    }
+
+    assert expected == RequestDecoder.decode(input)
+  end
+
+  test "Alert: badge + click_action" do
+    input = %Alert{
+      body: "A message from someone",
+      title: "Notification title",
+      badge: 7,
+      click_action: ".SomeApp.Handler.action"
+    }
+
+    expected = %{
+      body: "A message from someone",
+      title: "Notification title",
+      badge: 7,
+      click_action: ".SomeApp.Handler.action"
+    }
+
+    assert expected == RequestDecoder.decode(input)
+  end
+
+  test "Alert: tag + sound" do
+    input = %Alert{
+      body: "A message from someone",
+      title: "Notification title",
+      tag: "info",
+      sound: "standard.mp3"
+    }
+
+    expected = %{
+      body: "A message from someone",
+      title: "Notification title",
+      tag: "info",
+      sound: "standard.mp3"
+    }
+
+    assert expected == RequestDecoder.decode(input)
+  end
+
+  # AlertNotification
+
+  test "AlertNotification: decoder does well with all-fields schema" do
+    input = %AlertNotification{
+      service: "apns",
+      mode: "prod",
+      priority: "normal",
+      time_to_live: 3600,
+      mutable_content: true,
+      tags: ["some", "tags", "for", "pool", "selection"],
+      topic: "com.someapp",
+      alert: %Alert{
+        body: "A message from someone",
+        title: "Notification title",
+        badge: 7,
+        click_action: ".SomeApp.Handler.action",
+        tag: "info",
+        sound: "standard.mp3"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected = %{
+      service: :apns,
+      mode: :prod,
+      priority: :normal,
+      time_to_live: 3600,
+      mutable_content: true,
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title",
+        badge: 7,
+        tag: "info",
+        click_action: ".SomeApp.Handler.action",
+        sound: "standard.mp3"
+      },
+      topic: "com.someapp",
+      data: %{"acme1" => "value1", "acme2" => "value2"},
+      tags: ["some", "tags", "for", "pool", "selection"]
+    }
+
+    assert expected == RequestDecoder.decode(input)
+  end
+
+  test "AlertNotification: minimum fields schema" do
+    input = %AlertNotification{
+      service: "fcm",
+      alert: %Alert{
+        body: "A message from someone",
+        title: "Notification title"
+      }
+    }
+
+    expected = %{
+      service: :fcm,
+      mutable_content: false,
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title"
+      }
+    }
+
+    assert expected == RequestDecoder.decode(input)
+  end
+
+  # SilentNotification
+
+  test "SilentNotification: decoder does well with all-fields schema" do
+    input = %SilentNotification{
+      service: "apns",
+      mode: "prod",
+      priority: "normal",
+      time_to_live: 3600,
+      mutable_content: true,
+      tags: ["some", "tags", "for", "pool", "selection"],
+      topic: "com.someapp",
+      alert: %Alert{
+        body: "A message from someone",
+        title: "Notification title",
+        badge: 7,
+        click_action: ".SomeApp.Handler.action",
+        tag: "info",
+        sound: "standard.mp3"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected = %{
+      service: :apns,
+      mode: :prod,
+      priority: :normal,
+      time_to_live: 3600,
+      mutable_content: true,
+      tags: ["some", "tags", "for", "pool", "selection"],
+      topic: "com.someapp",
+      alert: %{
+        body: "A message from someone",
+        title: "Notification title",
+        badge: 7,
+        tag: "info",
+        click_action: ".SomeApp.Handler.action",
+        sound: "standard.mp3"
+      },
+      data: %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    assert expected == RequestDecoder.decode(input)
+  end
+
+  test "SilentNotification: minimum fields schema" do
+    input = %SilentNotification{
+      service: "fcm",
+      data: %{"acme1" => "value1", "acme2" => "value2"}
+    }
+
+    expected = %{
+      service: :fcm,
+      mutable_content: false,
+      data: %{"acme1" => "value1", "acme2" => "value2"}
     }
 
     assert expected == RequestDecoder.decode(input)


### PR DESCRIPTION
This pull request is the intuitive continuation of MIM-868 story, with the main difference that here I cover handling of the requests specified by APIv2 & APIv3.

In the home stretch it also turned out that I needed to - kind of - rollback to previous schemas design, reintroducing `MixedNotification` definition. Source rationale is that `OpenApiSpex` framework is not doing well when it finds incoming request matching more than one schema definition.