### PR TITLE
Use structured logs for sparrow

### DIFF
--- a/lib/mongoose_push/logger_fmt.ex
+++ b/lib/mongoose_push/logger_fmt.ex
@@ -38,6 +38,10 @@ defmodule MongoosePush.LoggerFmt do
     Enum.flat_map(metadata, &flatten_metadata_elem/1)
   end
 
+  defp flatten_metadata_elem({key, %_{} = value}) do
+    flatten_metadata_elem({key, Map.from_struct(value)})
+  end
+
   defp flatten_metadata_elem({key, value}) when is_map(value) do
     Enum.flat_map(value, fn {sub_key, sub_value} ->
       flatten_metadata_elem({"#{key}.#{sub_key}", sub_value})

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule MongoosePush.Mixfile do
   defp deps do
     [
       {:chatterbox, github: "joedevivo/chatterbox", ref: "1f4ce4f", override: true},
-      {:sparrow, github: "esl/sparrow", ref: "78ad18c"},
+      {:sparrow, github: "esl/sparrow", ref: "b1896ca"},
       {:plug_cowboy, "~> 2.0"},
       {:cowboy, "~> 2.3", override: true},
       {:jason, "~> 1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -48,7 +48,7 @@
   "pollution": {:hex, :pollution, "0.9.2", "3f67542631071c99f807d2a8f9da799c07cd983c902f5357b9e1569c20a26e76", [:mix], [], "hexpm", "6399fd8ffd97dcc3d9d277f60542a234d644d7bcc0d48c8fda93d6be4801bac2"},
   "quixir": {:hex, :quixir, "0.9.3", "f01c37386b9e1d0526f01a8734a6d7884af294a0ec360f05c24c7171d74632bd", [:mix], [{:pollution, "~> 0.9.2", [hex: :pollution, repo: "hexpm", optional: false]}], "hexpm", "4f3a1fe7c82b767d935b3f7b94cf34b91ef78bb487ef256b303d77417fc7d589"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm", "451d8527787df716d99dc36162fca05934915db0b6141bbdac2ea8d3c7afc7d7"},
-  "sparrow": {:git, "https://github.com/esl/sparrow.git", "78ad18c591c20dfe72e70587bb5d56aaaa4bb2ec", [ref: "78ad18c"]},
+  "sparrow": {:git, "https://github.com/esl/sparrow.git", "b1896ca4fb0ca18369dd62de3d4c82f14f5bc66e", [ref: "b1896ca"]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm", "13104d7897e38ed7f044c4de953a6c28597d1c952075eb2e328bc6d6f2bfc496"},
   "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm", "4738382e36a0a9a2b6e25d67c960e40e1a2c95560b9f936d8e29de8cd858480f"},
   "telemetry_metrics": {:hex, :telemetry_metrics, "0.4.2", "1de986fad9aa6bf81f8a33ddfd16e5d8ab0dec6272e624eb517c1a92a44d41a9", [:mix], [{:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "e56ffed2dbe293ab6cf7c94980faeb368cb360662c1927f54fc634a4ca55362e"},


### PR DESCRIPTION
* Update sparrow to include version that does structured logging via keywords
* Make `logfmt` formatter accept Elixir Structs (sparrow uses them a lot)