### PR TITLE
Metrics - refactoring notification send time

### DIFF
--- a/lib/mongoose_push/metrics/telemetry_metrics.ex
+++ b/lib/mongoose_push/metrics/telemetry_metrics.ex
@@ -10,10 +10,12 @@ defmodule MongoosePush.Metrics.TelemetryMetrics do
   def metrics do
     [
       # Summary is not yet supported in TelemetryMetricsPrometheus
-      Telemetry.Metrics.distribution("mongoose_push.notification.send.time",
-        buckets: [100, 250, 500, 1000],
-        tags: [:status, :service, :error_category, :error_reason],
-        unit: {:native, :second}
+      Telemetry.Metrics.distribution(
+        "mongoose_push.notification.send.time.microsecond",
+        event_name: [:mongoose_push, :notification, :send],
+        measurement: :time,
+        buckets: [1000, 10_000, 25_000, 50_000, 100_000, 250_000, 500_000, 1000_000],
+        tags: [:status, :service, :error_category, :error_reason]
       ),
 
       # measurement is ignored in Counter metric

--- a/test/unit/mongoose_push_telemetry_metrics_test.exs
+++ b/test/unit/mongoose_push_telemetry_metrics_test.exs
@@ -38,13 +38,13 @@ defmodule MongoosePushTelemetryMetricsTest do
 
     # Distribution metric contains count as well as the buckets
     fcm_regex =
-      ~r/mongoose_push_notification_send_time_count{error_category=\"\",error_reason=\"\",service=\"fcm\",status=\"success\"} (?<count>[\d]+)/
+      ~r/mongoose_push_notification_send_time_microsecond_count{error_category=\"\",error_reason=\"\",service=\"fcm\",status=\"success\"} (?<count>[\d]+)/
 
     fcm_match = Regex.named_captures(fcm_regex, metrics)
     fcm_count = get_count(fcm_match)
 
     apns_regex =
-      ~r/mongoose_push_notification_send_time_count{error_category=\"\",error_reason=\"\",service=\"apns\",status=\"success\"} (?<count>[\d]+)/
+      ~r/mongoose_push_notification_send_time_microsecond_count{error_category=\"\",error_reason=\"\",service=\"apns\",status=\"success\"} (?<count>[\d]+)/
 
     apns_match = Regex.named_captures(apns_regex, metrics)
     apns_count = get_count(apns_match)
@@ -68,10 +68,10 @@ defmodule MongoosePushTelemetryMetricsTest do
 
       # Distribution metric contains count as well as the buckets
       fcm_regex =
-        ~r/mongoose_push_notification_send_time_count{error_category=\"(?<type>[^\s]*)\",error_reason=\"(?<reason>[^\s]*)\",service=\"fcm\",status=\"error\"} (?<count>[\d]+)/
+        ~r/mongoose_push_notification_send_time_microsecond_count{error_category=\"(?<type>[^\s]*)\",error_reason=\"(?<reason>[^\s]*)\",service=\"fcm\",status=\"error\"} (?<count>[\d]+)/
 
       apns_regex =
-        ~r/mongoose_push_notification_send_time_count{error_category=\"(?<type>[^\s]*)\",error_reason=\"(?<reason>[^\s]*)\",service=\"apns\",status=\"error\"} (?<count>[\d]+)/
+        ~r/mongoose_push_notification_send_time_microsecond_count{error_category=\"(?<type>[^\s]*)\",error_reason=\"(?<reason>[^\s]*)\",service=\"apns\",status=\"error\"} (?<count>[\d]+)/
 
       fcm_matches =
         fcm_regex


### PR DESCRIPTION
This PR updates:
-  Metric definition with updated measurement units. 'second' was inconsistent with the histogram buckets and all events were smaller than the lowest bucket.
- Event name is overridden with prometheus recommended format that includes the unit of the measurement in the event name. 

Previous integration tests are checking this functionality, hence no need for additional tests. 