### PR TITLE
refactor api_v*_notification_controller tests

### DIFF
--- a/test/mongoose_push_web/controllers/api_v1_notification_controller_test.exs
+++ b/test/mongoose_push_web/controllers/api_v1_notification_controller_test.exs
@@ -17,67 +17,56 @@ defmodule MongoosePushWeb.APIv1NotificationControllerTest do
     assert json_response(conn, 200) == nil
   end
 
-  test "Request.SendNotification.FlatNotification schema without required service field", %{
-    conn: conn
-  } do
-    conn =
-      post(
-        conn,
-        "/v1/notification/666",
-        Jason.encode!(Map.drop(ControllersHelper.flat_request(), ["service"]))
-      )
+  @dropped_fields ["service", "body"]
+  for dropped <- @dropped_fields do
+    test "Request.SendNotification.FlatNotification schema without required #{dropped} field", %{
+      conn: conn
+    } do
+      body =
+        ControllersHelper.flat_request()
+        |> Map.drop([unquote(dropped)])
+        |> Jason.encode!()
 
-    assert json_response(conn, 422) == ControllersHelper.missing_field_response("service")
-  end
+      conn = post(conn, "/v1/notification/666", body)
 
-  test "Request.SendNotification.FlatNotification schema without required body field", %{
-    conn: conn
-  } do
-    conn =
-      post(
-        conn,
-        "/v1/notification/666",
-        Jason.encode!(Map.drop(ControllersHelper.flat_request(), ["body"]))
-      )
-
-    assert json_response(conn, 422) == ControllersHelper.missing_field_response("body")
+      assert json_response(conn, 422) ==
+               ControllersHelper.missing_field_response(unquote(dropped))
+    end
   end
 
   test "Request.SendNotification.FlatNotification schema with incorrect badge value", %{
     conn: conn
   } do
-    conn =
-      post(
-        conn,
-        "/v1/notification/666",
-        Jason.encode!(%{ControllersHelper.flat_request() | "badge" => "seven"})
-      )
+    body =
+      ControllersHelper.flat_request()
+      |> Map.put("badge", "seven")
+      |> Jason.encode!()
+
+    conn = post(conn, "/v1/notification/666", body)
 
     assert json_response(conn, 422) ==
              ControllersHelper.invalid_field_response("integer", "string", "badge")
   end
 
   test "Request.SendNotification.FlatNotification schema with unexpected field", %{conn: conn} do
-    conn =
-      post(
-        conn,
-        "/v1/notification/666",
-        Jason.encode!(Map.put(ControllersHelper.flat_request(), "field", "peek-a-boo"))
-      )
+    body =
+      ControllersHelper.flat_request()
+      |> Map.put("field", "peek-a-boo")
+      |> Jason.encode!()
 
+    conn = post(conn, "/v1/notification/666", body)
     assert json_response(conn, 422) == ControllersHelper.unexpected_field_response("field")
   end
 
   test "Request.SendNotification.FlatNotification schema with unsupported mode value", %{
     conn: conn
   } do
-    conn =
-      post(
-        conn,
-        "/v1/notification/666",
-        Jason.encode!(%{ControllersHelper.flat_request() | "mode" => "test"})
-      )
+    body =
+      ControllersHelper.flat_request()
+      |> Map.put("mode", "test")
+      |> Jason.encode!()
 
+    conn = post(conn, "/v1/notification/666", body)
     assert json_response(conn, 422) == ControllersHelper.invalid_value_for_enum("mode")
   end
 
@@ -146,7 +135,7 @@ defmodule MongoosePushWeb.APIv1NotificationControllerTest do
     assert json_response(conn, 503) == %{"details" => "Please try again later"}
   end
 
-  # decoder end-to-end tests
+  # decoder tests
 
   test "decoder test: all possible fields", %{conn: conn} do
     device_id = "1"

--- a/test/mongoose_push_web/controllers/api_v2_notification_controller_test.exs
+++ b/test/mongoose_push_web/controllers/api_v2_notification_controller_test.exs
@@ -12,63 +12,49 @@ defmodule MongoosePushWeb.APIv2NotificationControllerTest do
 
   test "correct Request.SendNotification.Deep.AlertNotification schema", %{conn: conn} do
     expect(MongoosePush.Notification.MockImpl, :push, fn _id, _req -> :ok end)
-
     conn = post(conn, "/v2/notification/654321", Jason.encode!(ControllersHelper.alert_request()))
     assert json_response(conn, 200) == nil
   end
 
-  test "Request.SendNotification.Deep.AlertNotification schema without required service field", %{
-    conn: conn
-  } do
-    conn =
-      post(
-        conn,
-        "/v2/notification/654321",
-        Jason.encode!(Map.drop(ControllersHelper.alert_request(), ["service"]))
-      )
+  @dropped_fields ["service", "alert"]
+  for dropped <- @dropped_fields do
+    test "Request.SendNotification.Deep.AlertNotification schema without required #{dropped} field",
+         %{
+           conn: conn
+         } do
+      body =
+        ControllersHelper.alert_request()
+        |> Map.drop([unquote(dropped)])
+        |> Jason.encode!()
 
-    assert json_response(conn, 422) == ControllersHelper.missing_field_response("service")
-  end
+      conn = post(conn, "/v2/notification/654321", body)
 
-  test "Request.SendNotification.Deep.AlertNotification schema without required alert field", %{
-    conn: conn
-  } do
-    conn =
-      post(
-        conn,
-        "/v2/notification/654321",
-        Jason.encode!(Map.drop(ControllersHelper.alert_request(), ["alert"]))
-      )
-
-    assert json_response(conn, 422) == ControllersHelper.missing_field_response("alert")
+      assert json_response(conn, 422) ==
+               ControllersHelper.missing_field_response(unquote(dropped))
+    end
   end
 
   test "Request.SendNotification.Deep.AlertNotification schema with incorrect priority value", %{
     conn: conn
   } do
-    conn =
-      post(
-        conn,
-        "/v2/notification/654321",
-        Jason.encode!(%{
-          ControllersHelper.alert_request()
-          | "priority" => "the highest in the world"
-        })
-      )
+    body =
+      ControllersHelper.alert_request()
+      |> Map.put("priority", "the highest in the world")
+      |> Jason.encode!()
 
+    conn = post(conn, "/v2/notification/654321", body)
     assert json_response(conn, 422) == ControllersHelper.invalid_value_for_enum("priority")
   end
 
   test "Request.SendNotification.Deep.AlertNotification schema with unexpected field", %{
     conn: conn
   } do
-    conn =
-      post(
-        conn,
-        "/v2/notification/654321",
-        Jason.encode!(Map.put(ControllersHelper.alert_request(), "field", "peek-a-boo"))
-      )
+    body =
+      ControllersHelper.alert_request()
+      |> Map.put("field", "peek-a-boo")
+      |> Jason.encode!()
 
+    conn = post(conn, "/v2/notification/654321", body)
     assert json_response(conn, 422) == ControllersHelper.unexpected_field_response("field")
   end
 
@@ -81,43 +67,34 @@ defmodule MongoosePushWeb.APIv2NotificationControllerTest do
     assert json_response(conn, 200) == nil
   end
 
-  test "Request.SendNotification.Deep.SilentNotification schema without required service field",
-       %{
-         conn: conn
-       } do
-    conn =
-      post(
-        conn,
-        "/v2/notification/654321",
-        Jason.encode!(Map.drop(ControllersHelper.silent_request(), ["service"]))
-      )
+  @dropped_fields [{"service", "service"}, {"data", "alert"}]
+  for {dropped, missing} <- @dropped_fields do
+    test "Request.SendNotification.Deep.SilentNotification schema without required #{dropped} field",
+         %{
+           conn: conn
+         } do
+      body =
+        ControllersHelper.silent_request()
+        |> Map.drop([unquote(dropped)])
+        |> Jason.encode!()
 
-    assert json_response(conn, 422) == ControllersHelper.missing_field_response("service")
-  end
+      conn = post(conn, "/v2/notification/654321", body)
 
-  test "Request.SendNotification.Deep.SilentNotification schema without required data field", %{
-    conn: conn
-  } do
-    conn =
-      post(
-        conn,
-        "/v2/notification/654321",
-        Jason.encode!(Map.drop(ControllersHelper.silent_request(), ["data"]))
-      )
-
-    assert json_response(conn, 422) == ControllersHelper.missing_field_response("alert")
+      assert json_response(conn, 422) ==
+               ControllersHelper.missing_field_response(unquote(missing))
+    end
   end
 
   test "Request.SendNotification.Deep.SilentNotification schema with incorrect time_to_live value",
        %{
          conn: conn
        } do
-    conn =
-      post(
-        conn,
-        "/v2/notification/654321",
-        Jason.encode!(%{ControllersHelper.silent_request() | "time_to_live" => "infinity"})
-      )
+    body =
+      ControllersHelper.alert_request()
+      |> Map.put("time_to_live", "infinity")
+      |> Jason.encode!()
+
+    conn = post(conn, "/v2/notification/654321", body)
 
     assert json_response(conn, 422) ==
              ControllersHelper.invalid_field_response("integer", "string", "time_to_live")
@@ -126,13 +103,12 @@ defmodule MongoosePushWeb.APIv2NotificationControllerTest do
   test "Request.SendNotification.Deep.SilentNotification schema with unexpected field", %{
     conn: conn
   } do
-    conn =
-      post(
-        conn,
-        "/v2/notification/654321",
-        Jason.encode!(Map.put(ControllersHelper.silent_request(), "field", "peek-a-boo"))
-      )
+    body =
+      ControllersHelper.alert_request()
+      |> Map.put("field", "peek-a-boo")
+      |> Jason.encode!()
 
+    conn = post(conn, "/v2/notification/654321", body)
     assert json_response(conn, 422) == ControllersHelper.unexpected_field_response("field")
   end
 
@@ -219,7 +195,7 @@ defmodule MongoosePushWeb.APIv2NotificationControllerTest do
     assert json_response(conn, 503) == %{"details" => "Please try again later"}
   end
 
-  # decoder end-to-end tests
+  # decoder tests
 
   test "AlertNotification decoder test: all possible fields", %{conn: conn} do
     device_id = "1"

--- a/test/mongoose_push_web/controllers/api_v3_notification_controller_test.exs
+++ b/test/mongoose_push_web/controllers/api_v3_notification_controller_test.exs
@@ -17,57 +17,45 @@ defmodule MongoosePushWeb.APIv3NotificationControllerTest do
     assert json_response(conn, 200) == nil
   end
 
-  test "Request.SendNotification.Deep.AlertNotification schema without required service field", %{
-    conn: conn
-  } do
-    conn =
-      post(
-        conn,
-        "/v3/notification/123456",
-        Jason.encode!(Map.drop(ControllersHelper.alert_request(), ["service"]))
-      )
+  @dropped_fields ["service", "alert"]
+  for dropped <- @dropped_fields do
+    test "Request.SendNotification.Deep.AlertNotification schema without required #{dropped} field",
+         %{
+           conn: conn
+         } do
+      body =
+        ControllersHelper.alert_request()
+        |> Map.drop([unquote(dropped)])
+        |> Jason.encode!()
 
-    assert json_response(conn, 422) == ControllersHelper.missing_field_response("service")
-  end
+      conn = post(conn, "/v3/notification/123456", body)
 
-  test "Request.SendNotification.Deep.AlertNotification schema without required alert field", %{
-    conn: conn
-  } do
-    conn =
-      post(
-        conn,
-        "/v3/notification/123456",
-        Jason.encode!(Map.drop(ControllersHelper.alert_request(), ["alert"]))
-      )
-
-    assert json_response(conn, 422) == ControllersHelper.missing_field_response("alert")
+      assert json_response(conn, 422) ==
+               ControllersHelper.missing_field_response(unquote(dropped))
+    end
   end
 
   test "Request.SendNotification.Deep.AlertNotification schema with incorrect priority value", %{
     conn: conn
   } do
-    conn =
-      post(
-        conn,
-        "/v3/notification/123456",
-        Jason.encode!(%{
-          ControllersHelper.alert_request()
-          | "priority" => "the highest in the world"
-        })
-      )
+    body =
+      ControllersHelper.alert_request()
+      |> Map.put("priority", "the highest in the world")
+      |> Jason.encode!()
 
+    conn = post(conn, "/v3/notification/123456", body)
     assert json_response(conn, 422) == ControllersHelper.invalid_value_for_enum("priority")
   end
 
   test "Request.SendNotification.Deep.AlertNotification schema with unexpected field", %{
     conn: conn
   } do
-    conn =
-      post(
-        conn,
-        "/v2/notification/123456",
-        Jason.encode!(Map.put(ControllersHelper.alert_request(), "field", "peek-a-boo"))
-      )
+    body =
+      ControllersHelper.alert_request()
+      |> Map.put("field", "peek-a-boo")
+      |> Jason.encode!()
+
+    conn = post(conn, "/v2/notification/123456", body)
 
     assert json_response(conn, 422) == ControllersHelper.unexpected_field_response("field")
   end
@@ -81,43 +69,34 @@ defmodule MongoosePushWeb.APIv3NotificationControllerTest do
     assert json_response(conn, 200) == nil
   end
 
-  test "Request.SendNotification.Deep.SilentNotification schema without required service field",
-       %{
-         conn: conn
-       } do
-    conn =
-      post(
-        conn,
-        "/v3/notification/123456",
-        Jason.encode!(Map.drop(ControllersHelper.silent_request(), ["service"]))
-      )
+  @dropped_fields [{"service", "service"}, {"data", "alert"}]
+  for {dropped, missing} <- @dropped_fields do
+    test "Request.SendNotification.Deep.SilentNotification schema without required #{missing} field",
+         %{
+           conn: conn
+         } do
+      body =
+        ControllersHelper.silent_request()
+        |> Map.drop([unquote(dropped)])
+        |> Jason.encode!()
 
-    assert json_response(conn, 422) == ControllersHelper.missing_field_response("service")
-  end
+      conn = post(conn, "/v3/notification/123456", body)
 
-  test "Request.SendNotification.Deep.SilentNotification schema without required data field", %{
-    conn: conn
-  } do
-    conn =
-      post(
-        conn,
-        "/v3/notification/123456",
-        Jason.encode!(Map.drop(ControllersHelper.silent_request(), ["data"]))
-      )
-
-    assert json_response(conn, 422) == ControllersHelper.missing_field_response("alert")
+      assert json_response(conn, 422) ==
+               ControllersHelper.missing_field_response(unquote(missing))
+    end
   end
 
   test "Request.SendNotification.Deep.SilentNotification schema with incorrect time_to_live value",
        %{
          conn: conn
        } do
-    conn =
-      post(
-        conn,
-        "/v3/notification/123456",
-        Jason.encode!(%{ControllersHelper.silent_request() | "time_to_live" => "infinity"})
-      )
+    body =
+      ControllersHelper.silent_request()
+      |> Map.put("time_to_live", "infinity")
+      |> Jason.encode!()
+
+    conn = post(conn, "/v3/notification/123456", body)
 
     assert json_response(conn, 422) ==
              ControllersHelper.invalid_field_response("integer", "string", "time_to_live")
@@ -126,13 +105,12 @@ defmodule MongoosePushWeb.APIv3NotificationControllerTest do
   test "Request.SendNotification.Deep.SilentNotification schema with unexpected field", %{
     conn: conn
   } do
-    conn =
-      post(
-        conn,
-        "/v3/notification/123456",
-        Jason.encode!(Map.put(ControllersHelper.silent_request(), "field", "peek-a-boo"))
-      )
+    body =
+      ControllersHelper.silent_request()
+      |> Map.put("field", "peek-a-boo")
+      |> Jason.encode!()
 
+    conn = post(conn, "/v3/notification/123456", body)
     assert json_response(conn, 422) == ControllersHelper.unexpected_field_response("field")
   end
 
@@ -210,7 +188,7 @@ defmodule MongoosePushWeb.APIv3NotificationControllerTest do
     post_and_assert_error(conn, 500, {:generic, :unspecified}, :unspecified)
   end
 
-  # decoder end-to-end tests
+  # decoder tests
 
   test "AlertNotification decoder test: all possible fields", %{conn: conn} do
     device_id = "1"


### PR DESCRIPTION
Here I introduce some quick refactor of the test suites developed while incorporating `OpenApiSpex` to the project, originally proposed by @aleklisi in #168. Since these changes has been interfering with the ones from #172, decreasing their readability, I decided to extract them to the separate PR.