### PR TITLE
Pass the logformat variable to function setting the formatter

### DIFF
--- a/lib/mongoose_push/application.ex
+++ b/lib/mongoose_push/application.ex
@@ -29,7 +29,7 @@ defmodule MongoosePush.Application do
     loglevel = Application.get_env(:mongoose_push, :logging)[:level] || :info
     logformat = Application.get_env(:mongoose_push, :logging)[:format] || :logfmt
     set_loglevel(loglevel)
-    set_logformat(loglevel)
+    set_logformat(logformat)
 
     # Mostly status logging
     _ = check_runtime_configuration_status()


### PR DESCRIPTION
Previously the `loglevel` was accidentally passed and our tests didn't catch it.