### PR TITLE
move from rslota/beam-builder to mongooseim/beam-builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ executors:
         type: string
         default: test
     docker:
-      - image: rslota/beam-builder:erlang-<< parameters.erlang_version >>_elixir-<< parameters.elixir_version >>
+      - image: mongooseim/beam-builder:erlang-<< parameters.erlang_version >>_elixir-<< parameters.elixir_version >>
       - image: mongooseim/fcm-mock-server
       - image: mobify/apns-http2-mock-server
     working_directory: ~/app


### PR DESCRIPTION
As per PR description, we are moving to esl fork of `beam-builder`, which also means we are moving to `mongooseim/beam-builder` repository on Docker Hub, which I populated with proper images today.