### PR TITLE
Deploy documentation to GH Pages from CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,12 +299,6 @@ jobs:
               sudo apt-get update && \
               sudo apt-get install -y esl-erlang=1:21.0 && \
               sudo apt-get install -y elixir=1.8.0-1
-              wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz && \
-              sudo chmod +x dockerize-linux-amd64-v0.6.1.tar.gz && \
-              sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz && \
-              sudo chmod +x /usr/local/bin/dockerize && \
-              sudo rm dockerize-linux-amd64-v0.6.1.tar.gz
-
       - restore_cache:
           keys:
               - mix-cache-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,8 +317,8 @@ jobs:
       - run:
           name: Configure Git
           command: |
-              git config --global user.email "builds@circleci.com"
-              git config --global user.name "CircleCI"
+              git config --global user.email "mongoosepushbot@erlang-solutions.com"
+              git config --global user.name "mongoosepushbot"
       - add_ssh_keys:
           fingerprints:
             - "${GH_DEPLOY_KEY}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,6 +286,53 @@ jobs:
                docker push $DOCKERHUB_REPOSITORY/$DOCKER_IMAGE:latest
              fi
 
+  gh-pages-deploy:
+    machine:
+        image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          name: Install elixir
+          command: |
+              wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
+              sudo dpkg -i erlang-solutions_1.0_all.deb && \
+              sudo apt-get update && \
+              sudo apt-get install -y esl-erlang=1:21.0 && \
+              sudo apt-get install -y elixir=1.8.0-1
+              wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz && \
+              sudo chmod +x dockerize-linux-amd64-v0.6.1.tar.gz && \
+              sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz && \
+              sudo chmod +x /usr/local/bin/dockerize && \
+              sudo rm dockerize-linux-amd64-v0.6.1.tar.gz
+
+      - restore_cache:
+          keys:
+              - mix-cache-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}
+      - restore_cache:
+          keys:
+              - certs-cache-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}
+      - run:
+          name: Compile mix deps
+          command: mix do deps.get, deps.compile
+      - run:
+          name: Configure Git
+          command: |
+              git config --global user.email "builds@circleci.com"
+              git config --global user.name "CircleCI"
+      - add_ssh_keys:
+          fingerprints:
+            - "${GH_DEPLOY_KEY}"
+      - run:
+          name: Generate docs
+          command: |
+              set -x
+              if [ -n "$CIRCLE_TAG" ]; then
+                  mix gh_pages_docs $CIRCLE_TAG
+              elif [ "$CIRCLE_BRANCH" == "master" ]; then
+                  mix gh_pages_docs latest
+              fi
+
+
 workflows:
   version: 2
   build_and_test:
@@ -333,3 +380,12 @@ workflows:
             - build-docker-image
             - test-erlang-22_elixir-1-9
           filters: *all_tags
+
+      - gh-pages-deploy:
+          requires:
+            - pre-build
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+([a-z0-9\-\+\.])*/
+            branches:
+              only: master

--- a/lib/mix/tasks/gh_pages_docs.ex
+++ b/lib/mix/tasks/gh_pages_docs.ex
@@ -10,36 +10,59 @@ defmodule Mix.Tasks.GhPagesDocs do
   @shortdoc "Update a documentation version on GH Pages."
 
   @spec run(term) :: :ok
-  def run(_args) do
-    version = "v#{Project.config()[:version]}"
+  def run([version]) do
+    unless File.read!("assets/js/versions.js") |> String.contains?(version) do
+      update_versions_js()
+    end
 
-    case File.read!("assets/js/versions.js") |> String.contains?(version) do
-      true ->
-        Mix.Task.run("docs")
-        File.cd!("doc")
-        Mix.shell().cmd("git stash")
+    Mix.Task.run("docs")
+    File.cd!("doc")
+    Mix.shell().cmd("git stash")
 
-        Mix.shell().cmd("git checkout gh-pages")
+    Mix.shell().cmd("git checkout gh-pages")
 
-        case File.mkdir("../#{version}") do
-          result when result in [:ok, {:error, :eexist}] ->
-            Mix.shell().cmd("cp -r ./* ../#{version}")
-            File.cd!("..")
-            Mix.shell().cmd("ls")
-            Mix.shell().cmd("git add #{version}/*")
-            Mix.shell().cmd("git commit -m \"Update #{version}\"")
-            Mix.shell().cmd("rm -rf doc")
-            Mix.shell().cmd("git push origin gh-pages")
+    case File.mkdir("../#{version}") do
+      result when result in [:ok, {:error, :eexist}] ->
+        Mix.shell().cmd("cp -r ./* ../#{version}")
+        File.cd!("..")
+        Mix.shell().cmd("ls")
+        Mix.shell().cmd("git add #{version}/*")
 
-          _ ->
-            Mix.raise("Cannot create the #{version} directory")
+        unless File.read!("assets/js/versions.js") |> String.contains?(version) do
+          update_versions_js()
         end
 
+        Mix.shell().cmd("git add assets/js/versions.js")
+        Mix.shell().cmd("git commit -m \"Add content for #{version}\"")
+        Mix.shell().cmd("rm -rf doc")
+        Mix.shell().cmd("git show ")
+        Mix.shell().cmd("git push origin gh-pages")
+
       _ ->
-        Mix.raise("""
-        The assets/js/versions.js file is out of date.
-        Please add the newest version to the list.
-        """)
+        Mix.raise("Cannot create the #{version} directory")
     end
+  end
+
+  defp update_versions_js() do
+    {output, 0} = System.cmd("git", ["tag"], [])
+
+    versions =
+      output
+      |> String.split("\n")
+      |> Enum.drop(7)
+      |> Enum.drop(-1)
+      |> Enum.map(&v/1)
+      |> List.insert_at(0, "latest")
+      |> Enum.map(&version_elem/1)
+      |> Enum.join(",\n")
+
+    File.write!("assets/js/versions.js", "var versionNodes = [\n#{versions}\n]")
+  end
+
+  defp v(version), do: "v#{version}"
+
+  defp version_elem(version) do
+    "\t {\n\t\tversion: \"#{version}\",
+     \turl: \"https://esl.github.io/MongoosePush/#{version}/readme.html\"\n\t }"
   end
 end

--- a/lib/mix/tasks/gh_pages_docs.ex
+++ b/lib/mix/tasks/gh_pages_docs.ex
@@ -23,18 +23,18 @@ defmodule Mix.Tasks.GhPagesDocs do
 
     Mix.Task.run("docs")
     File.cd!("doc")
-    Mix.shell().cmd("git stash")
+    0 = Mix.shell().cmd("git stash")
 
     # ignore all the changes, the only changes we want to track are in the
     # doc directory which is listed in .gitignore
 
-    Mix.shell().cmd("git checkout gh-pages")
+    0 = Mix.shell().cmd("git checkout gh-pages")
 
     case File.mkdir("../#{version}") do
       result when result in [:ok, {:error, :eexist}] ->
-        Mix.shell().cmd("cp -r ./* ../#{version}")
+        0 = Mix.shell().cmd("cp -r ./* ../#{version}")
         File.cd!("..")
-        Mix.shell().cmd("git add #{version}/*")
+        0 = Mix.shell().cmd("git add #{version}/*")
 
         unless String.contains?(File.read!("assets/js/versions.js"), version) do
           update_versions_js()
@@ -42,11 +42,11 @@ defmodule Mix.Tasks.GhPagesDocs do
 
         update_index_html()
 
-        Mix.shell().cmd("git add assets/js/versions.js")
-        Mix.shell().cmd("git add index.html")
-        Mix.shell().cmd("git commit -m \"Add content for #{version}\"")
-        Mix.shell().cmd("rm -rf doc")
-        Mix.shell().cmd("git push origin gh-pages")
+        0 = Mix.shell().cmd("git add assets/js/versions.js")
+        0 = Mix.shell().cmd("git add index.html")
+        0 = Mix.shell().cmd("git commit -m \"Add content for #{version}\"")
+        0 = Mix.shell().cmd("rm -rf doc")
+        0 = Mix.shell().cmd("git push origin gh-pages")
 
       _ ->
         Mix.raise("Cannot create the #{version} directory")

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule MongoosePush.Mixfile do
     [
       javascript_config_path: "../assets/js/versions.js",
       extras: [
-        "README.md": [file: "guides/introduction", title: "Introduction"],
+        "README.md": [file: "guides/readme", title: "Introduction"],
         "guides/configuration.md": [file: "guides/configuration", title: "Configuration"],
         "guides/local_build.md": [file: "guides/local_build", title: "Local build"],
         "guides/test.md": [file: "guides/test", title: "Running tests"],


### PR DESCRIPTION
Add a CCI job which builds new documentation for every new tag and updates the latest version on every commit to master.