### PR TITLE
Add migration instructions for configuration files

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -37,7 +37,7 @@ config :mongoose_push, fcm: [
 This is a definition of a pool - each pool has a name and a configuration. It is possible to have multiple named pools with different configuration, which includes pool size, environment mode, etc. Currently the only reason you may want to do this is to create separate production and development pools which may be selected by an `HTTP` client by specifying matching `:mode` in their push request.
 
 Each `FCM` pool may be configured by setting the following fields:
-* **appfile** (*required*) - path to an `FCM` service account JSON file. Details on how to get one are in the [Running from DockerHub](docker.html#running-from-dockerhub) section
+* **appfile** (*required*) - path to an `FCM` service account JSON file. Details on how to get one are in the [Running from DockerHub](docker.md#running-from-dockerhub) section
 * **pool_size** (*required*) - maximum number of used `HTTP/2` connections to google's service
 * **mode** (*either `:prod` or `:dev`*) - pool's mode. The `HTTP` client may select a pool used to push a notification by specifying a matching option in the request
 * **endpoint** (*optional*) - URL override for the `FCM` service. Useful mainly in tests
@@ -121,16 +121,16 @@ Environment variables to configure a production release.
 
 #### Settings for FCM service:
 * `PUSH_FCM_ENDPOINT` - Hostname of the `FCM` service. Set only for local testing. By default this option points to the Google's official hostname
-* `PUSH_FCM_APP_FILE` - Path to the `FCM` service account JSON file. For details look at [Running from DockerHub](docker.html#running-from-dockerhub) section
+* `PUSH_FCM_APP_FILE` - Path to the `FCM` service account JSON file. For details look at [Running from DockerHub](docker.md#running-from-dockerhub) section
 * `PUSH_FCM_POOL_SIZE` - Connection pool size for the `FCM` service
 
 #### Settings for development APNS service:
 * `PUSH_APNS_DEV_ENDPOINT` - Hostname of the `APNS` service. Set only for local testing. By default this option points to the Apple's official hostname
 * `PUSH_APNS_DEV_CERT` - Path to Apple's development certfile used to communicate with `APNS`
 * `PUSH_APNS_DEV_KEY` - Path to Apple's development keyfile used to communicate with `APNS`
-* `PUSH_APNS_DEV_KEY_ID` - Key ID generated from Apple's developer console. For details look at the [Running from DockerHub](docker.html#running-from-dockerhub) section *required for token authentication*
-* `PUSH_APNS_DEV_TEAM_ID` - TEAM ID generated from Apple's developer console. For details look at the [Running from DockerHub](docker.html#running-from-dockerhub) section *required for token authenticaton*
-* `PUSH_APNS_DEV_P8_TOKEN` - Token generated from Apple's developer console. For details look at the [Running from DockerHub](docker.html#running-from-dockerhub) section
+* `PUSH_APNS_DEV_KEY_ID` - Key ID generated from Apple's developer console. For details look at the [Running from DockerHub](docker.md#running-from-dockerhub) section *required for token authentication*
+* `PUSH_APNS_DEV_TEAM_ID` - TEAM ID generated from Apple's developer console. For details look at the [Running from DockerHub](docker.md#running-from-dockerhub) section *required for token authenticaton*
+* `PUSH_APNS_DEV_P8_TOKEN` - Token generated from Apple's developer console. For details look at the [Running from DockerHub](docker.md#running-from-dockerhub) section
 * `PUSH_APNS_DEV_USE_2197` - `true`/`false` - Enable or disable the use of an alternative `2197` port for `APNS` connections in development mode. Disabled by default
 * `PUSH_APNS_DEV_POOL_SIZE` - Connection pool size for `APNS` service in development mode
 * `PUSH_APNS_DEV_DEFAULT_TOPIC` - Default `APNS` topic to be set if the client app doesn't specify it with the API call. If this option is not set, MongoosePush will try to extract this value from the provided APNS certificate (the first topic will be assumed default). DEV certificates normally don't provide any topics, so this option can be safely left unset
@@ -139,9 +139,9 @@ Environment variables to configure a production release.
 * `PUSH_APNS_PROD_ENDPOINT` - Hostname of the `APNS` service. Set only for local testing. By default this option points to the Apple's official hostname
 * `PUSH_APNS_PROD_CERT` - Path to Apple's production certfile used to communicate with `APNS`
 * `PUSH_APNS_PROD_KEY` - Path to Apple's production keyfile used to communicate with `APNS`
-* `PUSH_APNS_PROD_KEY_ID` - Key ID generated from Apple's developer console. For details look at the [Running from DockerHub](docker.html#running-from-dockerhub) section *required for token authentication*
-* `PUSH_APNS_PROD_TEAM_ID` - TEAM ID generated from Apple's developer console. For details look at the  [Running from DockerHub](docker.html#running-from-dockerhub) section *required for token authenticaton*
-* `PUSH_APNS_PROD_P8_TOKEN` - Token generated from Apple's developer console. For details look at the [Running from DockerHub](docker.html#running-from-dockerhub) section
+* `PUSH_APNS_PROD_KEY_ID` - Key ID generated from Apple's developer console. For details look at the [Running from DockerHub](docker.md#running-from-dockerhub) section *required for token authentication*
+* `PUSH_APNS_PROD_TEAM_ID` - TEAM ID generated from Apple's developer console. For details look at the  [Running from DockerHub](docker.md#running-from-dockerhub) section *required for token authenticaton*
+* `PUSH_APNS_PROD_P8_TOKEN` - Token generated from Apple's developer console. For details look at the [Running from DockerHub](docker.md#running-from-dockerhub) section
 * `PUSH_APNS_PROD_USE_2197` - `true`/`false` - Enable or disable the use of an alternative `2197` port for `APNS` connections in production mode. Disabled by default
 * `PUSH_APNS_PROD_POOL_SIZE` - Connection pool size for `APNS` service in production mode
 * `PUSH_APNS_PROD_DEFAULT_TOPIC` - Default `APNS` topic to be set if the client app doesn't specify it with the API call. If this option is not set, MongoosePush will try to extract this value from the provided APNS certificate (the first topic will be assumed default)

--- a/guides/docker.md
+++ b/guides/docker.md
@@ -48,4 +48,4 @@ The docker image that you have just built, exposes the port `8443` for the HTTP 
 
 ## Configuration (basic)
 
-The docker image of MongoosePush contains common, basic configuration that is generated from `config/prod.exs`. All useful options may be overridden via [environment variables](configuration.html#environment-variables). However, if there's something you feel you need to change other than that, then you need to prepare your own `config/prod.exs` before image build.
+The docker image of MongoosePush contains common, basic configuration that is generated from `config/prod.exs`. All useful options may be overridden via [environment variables](configuration.md#environment-variables). However, if there's something you feel you need to change other than that, then you need to prepare your own `config/prod.exs` before image build.

--- a/guides/local_build.md
+++ b/guides/local_build.md
@@ -23,7 +23,7 @@ After this step you may try to run the service via:
 _build/prod/rel/mongoose_push/bin/mongoose_push foreground
 ```
 
-Yeah, I know... It crashed. Running this service is fast and simple but unfortunately you can't have push notifications without a properly configured `FCM` and/or `APNS` service. You can find out how to properly configure it in the [configuration](configuration.html#content) section.
+Yeah, I know... It crashed. Running this service is fast and simple but unfortunately you can't have push notifications without a properly configured `FCM` and/or `APNS` service. You can find out how to properly configure it in the [configuration](configuration.md#content) section.
 
 ## Development release
 

--- a/guides/migrations/2.0.x_2.1.0.md
+++ b/guides/migrations/2.0.x_2.1.0.md
@@ -1,0 +1,136 @@
+# Migration guide from 2.0.x to 2.1.0
+
+Please note that for standard usage, when configuring MongoosePush only with the environmental variables, the `config/*.exs` files are upgraded automatically and there is no action required from your end.
+If your MongoosePush is using modified `config/*.exs` files, please have a closer look at the changes presented below to see if you have to adjust your custom configuration.
+In such case, there could be a few changes necessary in the configuration files and a few additional, optional ones.
+
+## Main config (`config/config.exs`)
+
+MongoosePush supports structured logging in 2.1.0 release. To use that feature, there is a need to change logger configuration to use the new default.
+Old logger config:
+
+```elixir
+config :logger, :console,
+  format: "\n$dateT$time [$level] $metadata$levelpad$message\n",
+  metadata: [:pid]
+```
+
+New logger config:
+```elixir
+config :logger, :console,
+  format: {MongoosePush.Logger.LogFmt, :format},
+  metadata: :all
+```
+Further notes on logging are in the [logging section](2.0.x_2.1.0.md#logging)
+
+Additionally there are a few new defaults needed to be set up:
+```elixir
+config :mongoose_push, MongoosePush.Service,
+  fcm: MongoosePush.Service.FCM,
+  apns: MongoosePush.Service.APNS
+
+config :mongoose_push, backend_module: MongoosePush
+
+config :phoenix, :json_library, Jason
+```
+
+Lastly, since 2.1.0 MongoosePush uses `Phoenix` instead of `Maru` and Maru config entry can be removed.
+```elixir
+config :maru, :test, false
+```
+
+## Environmental configs (`config/{prod|dev|test}.exs`)
+
+### `Phoenix` in place of `Maru`
+As mentioned earlier, MongoosePush uses `Phoenix` and the config has to be updated to reflect that change.
+Old `Maru` config entry:
+```elixir
+config :maru, MongoosePush.Router,
+  versioning: [
+    using: :path
+  ],
+  https: [
+    bind_addr: {:system, :string, "PUSH_HTTPS_BIND_ADDR", "127.0.0.1"},
+    port: {:system, :integer, "PUSH_HTTPS_PORT", 8443},
+    keyfile: {:system, :string, "PUSH_HTTPS_KEYFILE", "priv/ssl/fake_key.pem"},
+    certfile: {:system, :string, "PUSH_HTTPS_CERTFILE", "priv/ssl/fake_cert.pem"},
+    cacertfile: {:system, :string, "PUSH_HTTPS_CERTFILE", "priv/ssl/fake_cert.pem"},
+    acceptors: {:system, :integer, "PUSH_HTTPS_ACCEPTORS", 100},
+    otp_app: :mongoose_push
+  ]
+```
+It should be removed completely and in its place there must be the new, `Phoenix` config entry:
+```elixir
+config :mongoose_push, MongoosePushWeb.Endpoint,
+  https: [
+    ip: {
+      :system,
+      # Custom type parser (Phoenix needs erlang-inet-style IP address)
+      {MongoosePush.Config.Utils, :parse_bind_addr, []},
+      "PUSH_HTTPS_BIND_ADDR",
+      {127, 0, 0, 1}
+    },
+    port: {:system, :integer, "PUSH_HTTPS_PORT", 8443},
+    keyfile: {:system, :string, "PUSH_HTTPS_KEYFILE", "priv/ssl/fake_key.pem"},
+    certfile: {:system, :string, "PUSH_HTTPS_CERTFILE", "priv/ssl/fake_cert.pem"},
+    cacertfile: {:system, :string, "PUSH_HTTPS_CERTFILE", "priv/ssl/fake_cert.pem"},
+    protocol_options: [
+      # https://ninenines.eu/docs/en/cowboy/2.5/manual/cowboy_http/
+    ],
+    transport_options: [
+      # https://ninenines.eu/docs/en/ranch/1.6/manual/ranch_tcp/
+      # https://ninenines.eu/docs/en/ranch/1.6/manual/ranch_ssl/
+      num_acceptors: {:system, :integer, "PUSH_HTTPS_ACCEPTORS", 100}
+    ],
+    otp_app: :mongoose_push
+  ],
+  debug_errors: false,
+  code_reloader: false,
+  check_origin: true,
+  server: true
+  ```
+  As you can see, there is no change in the variables used to parse the options.
+
+### Logging
+Old logging entry looked like that:
+```elixir
+config :mongoose_push, loglevel: {:system, :atom, "PUSH_LOGLEVEL", :info}
+```
+
+New logging entry may look like that:
+```elixir
+config :mongoose_push, :logging,
+  level: {:system, :atom, "PUSH_LOGLEVEL", :info},
+  format: {:system, :atom, "PUSH_LOGFORMAT", :json}
+```
+
+The structure changed a little and there is a new variable, `PUSH_LOGFORMAT`.
+It defaults to `:json` for the `prod` environment, and to `:logfmt` for the `dev` and `test` environments.
+The `logfmt` backend was changed to support structured logging.
+Please note that if you had a MongoosePush node configured with a log aggregation backend it probably needs to be reconfigured to match the current format of the log messages.
+You might also want to consider using the second standard, `JSON`, that MongoosePush now supports.
+
+### OpenAPI
+MongoosePush can expose OpenAPI specification if enabled. Config entry may look like this:
+```elixir
+config :mongoose_push,
+  openapi: [
+    expose_spec: {:system, :boolean, "PUSH_OPENAPI_EXPOSE_SPEC", false},
+    expose_ui: {:system, :boolean, "PUSH_OPENAPI_EXPOSE_UI", false}
+  ]
+  ```
+`PUSH_OPENAPI_EXPOSE_SPEC` enables OpenAPI endpoint support and `PUSH_OPENAPI_EXPOSE_UI` enables SwaggerUI.
+Both these options are disabled by default. For more details refer to the [configuration guide](../configuration.md#general-settings).
+
+### Elixometer
+MongoosePush does not use `Elixometer` for its metrics anymore. Metrics are provided using `Telemetry` and `elixometer` config entry should be removed.
+Old `elixometer` entry:
+```elixir
+config :elixometer,
+  reporter: :exometer_report_tty,
+  env: Mix.env(),
+  metric_prefix: "mongoose_push"
+  ```
+
+There is no config entry necessary for `Telemetry` metrics.
+To learn more about the new metrics and see how to setup default Grafana dashboards check out the [metrics guide](../metrics.md).

--- a/guides/migrations/2.0.x_2.1.0.md
+++ b/guides/migrations/2.0.x_2.1.0.md
@@ -1,12 +1,12 @@
 # Migration guide from 2.0.x to 2.1.0
 
-Please note that for standard usage, when configuring MongoosePush only with the environmental variables, the `config/*.exs` files are upgraded automatically and there is no action required from your end.
+Please note that for standard usage, when configuring MongoosePush only with environmental variables, the `config/*.exs` files are upgraded automatically and there is no action required from your end.
 If your MongoosePush is using modified `config/*.exs` files, please have a closer look at the changes presented below to see if you have to adjust your custom configuration.
 In such case, there could be a few changes necessary in the configuration files and a few additional, optional ones.
 
 ## Main config (`config/config.exs`)
 
-MongoosePush supports structured logging in 2.1.0 release. To use that feature, there is a need to change logger configuration to use the new default.
+MongoosePush supports structured logging from the 2.1.0 release. To use that feature, there is a need to change the logger configuration to use the new default.
 Old logger config:
 
 ```elixir
@@ -92,12 +92,12 @@ config :mongoose_push, MongoosePushWeb.Endpoint,
   As you can see, there is no change in the variables used to parse the options.
 
 ### Logging
-Old logging entry looked like that:
+Old logging entry looked like this:
 ```elixir
 config :mongoose_push, loglevel: {:system, :atom, "PUSH_LOGLEVEL", :info}
 ```
 
-New logging entry may look like that:
+New logging entry may look like the following:
 ```elixir
 config :mongoose_push, :logging,
   level: {:system, :atom, "PUSH_LOGLEVEL", :info},
@@ -134,3 +134,8 @@ config :elixometer,
 
 There is no config entry necessary for `Telemetry` metrics.
 To learn more about the new metrics and see how to setup default Grafana dashboards check out the [metrics guide](../metrics.md).
+
+### API
+
+Please note that API v2 is deprecated and will be removed in the future.
+API v2 and v3 differ only by the returned status and content in case of errors, so in case you are using API v2 please consider changing to API v3.


### PR DESCRIPTION
This PR introduces a first version of the migration guide. For now it includes changes in the configuration files only. 
Additionally, there are changes to the relative links to the other parts of the documentation as they were not working properly