### PR TITLE
Assert TLS configuration when booting MongoosePush

### DIFF
--- a/lib/mongoose_push/application.ex
+++ b/lib/mongoose_push/application.ex
@@ -210,23 +210,13 @@ defmodule MongoosePush.Application do
   end
 
   defp check_apns_ciphers() do
-    all_ciphers = :ssl.cipher_suites()
-
-    apns_ciphers =
-      Enum.filter(all_ciphers, fn cipher ->
-        case cipher do
-          {:ecdhe_rsa, :aes_128_gcm, _, :sha256} ->
-            true
-
-          {:ecdhe_rsa, :aes_256_gcm, _, :sha384} ->
-            true
-
-          _ ->
-            false
-        end
+    apns_ciphers_present =
+      Enum.any?(:ssl.cipher_suites(), fn x ->
+        x == {:ecdhe_rsa, :aes_128_gcm, :aead, :sha256} ||
+          x == {:ecdhe_rsa, :aes_256_gcm, :aead, :sha384}
       end)
 
-    case length(apns_ciphers) > 0 do
+    case apns_ciphers_present do
       true ->
         :ok
 


### PR DESCRIPTION
The purpose of this PR is to prevent MPush from start when APNS required ciphers (`ECDHE-RSA-AES128-GCM-SHA256` and `ECDHE-RSA-AES256-GCM-SHA384`) are not available in runtime. In this scenario user receives error message, briefly explaining what's going on.
Use case examples:
```
$ _build/prod/rel/mongoose_push/bin/mongoose_push foreground
when=2020-07-17T17:36:03.985 severity=info what=init text="Starting PoolsWarden" at=Elixir.Sparrow.PoolsWarden.init/1:95 pid=#PID<0.1826.0> result=success worker=pools_warden file=lib/sparrow/pools_warden.ex application=sparrow
{"application":"mongoose_push","at":"Elixir.MongoosePush.Application.check_apns_ciphers/0:234","file":"lib/mongoose_push/application.ex","pid":"#PID<0.1880.0>","reason":"no_apns_ciphers","severity":"error","status":"error","text":"APNS required ciphers missing","what":"tls_configuration","when":"2020-07-17T17:36:04.040"}
{"at":"application_controller.info_exited/3:1943","file":"application_controller.erl","pid":"#PID<0.1660.0>","severity":"info","text":"Application mongoose_push exited: MongoosePush.Application.start(:normal, []) returned an error: :no_apns_ciphers","what":"","when":"2020-07-17T17:36:04.040"}
=SUPERVISOR REPORT==== 17-Jul-2020::17:36:04.066666 ===
    supervisor: {local,gr_counter_sup}
    errorContext: child_terminated
    reason: killed
    offender: [{pid,<0.1742.0>},
               {id,gr_lager_default_tracer_counters},
               {mfargs,{gr_counter,start_link,
                                   [gr_lager_default_tracer_counters]}},
               {restart_type,transient},
               {shutdown,brutal_kill},
               {child_type,worker}]

=SUPERVISOR REPORT==== 17-Jul-2020::17:36:04.066749 ===
    supervisor: {local,gr_param_sup}
    errorContext: child_terminated
    reason: killed
    offender: [{pid,<0.1741.0>},
               {id,gr_lager_default_tracer_params},
               {mfargs,{gr_param,start_link,[gr_lager_default_tracer_params]}},
               {restart_type,transient},
               {shutdown,brutal_kill},
               {child_type,worker}]

{"Kernel pid terminated",application_controller,"{application_start_failure,mongoose_push,{no_apns_ciphers,{'Elixir.MongoosePush.Application',start,[normal,[]]}}}"}
Kernel pid terminated (application_controller) ({application_start_failure,mongoose_push,{no_apns_ciphers,{'Elixir.MongoosePush.Application',start,[normal,[]]}}})

Crash dump is being written to: erl_crash.dump...done
```
```
$ iex -S mix
Erlang/OTP 23 [erts-11.0] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [hipe]

Compiling 60 files (.ex)
Compiling 1 file (.erl)
when=2020-07-17T17:40:32.855 severity=info what=init text="Starting PoolsWarden" at=Elixir.Sparrow.PoolsWarden.init/1:95 pid=#PID<0.809.0> result=success worker=pools_warden file=lib/sparrow/pools_warden.ex application=sparrow
when=2020-07-17T17:40:32.955 severity=error what=tls_configuration text="APNS required ciphers missing" at=Elixir.MongoosePush.Application.check_apns_ciphers/0:234 pid=#PID<0.841.0> reason=no_apns_ciphers status=error file=lib/mongoose_push/application.ex application=mongoose_push
** (Mix) Could not start application mongoose_push: MongoosePush.Application.start(:normal, []) returned an error: :no_apns_ciphers
```