### PR TITLE
Replace APNs mock with kamilwaz/apns-mock-server

### DIFF
--- a/test/docker/docker-compose.mocks.yml
+++ b/test/docker/docker-compose.mocks.yml
@@ -8,7 +8,7 @@ services:
       - "4001:4001"
       - "4000:4000"
   apns-mock:
-    image: mobify/apns-http2-mock-server
+    image: kamilwaz/apns-mock-server
     container_name: apns-mock
     ports:
       - "2197:2197"

--- a/test/support/api.ex
+++ b/test/support/api.ex
@@ -64,7 +64,7 @@ defmodule MongoosePush.Support.API do
     {:ok, conn} = get_connection(:apns)
     payload = Poison.encode!(json)
 
-    headers = headers("POST", "/error-tokens", payload)
+    headers = headers("POST", "/mock/error-tokens", payload)
     :h2_client.send_request(conn, headers, payload)
     {"200", _payload} = get_response(conn)
     :ok
@@ -81,9 +81,9 @@ defmodule MongoosePush.Support.API do
   def reset(:apns) do
     {:ok, conn} = get_connection(:apns)
     payload = ""
-    headers = headers("POST", "/reset", payload)
+    headers = headers("POST", "/mock/reset", payload)
     :h2_client.send_request(conn, headers, payload)
-    {"200", "OK"} = get_response(conn)
+    {"200", ""} = get_response(conn)
     :ok
   end
 

--- a/test/unit/mongoose_push_test.exs
+++ b/test/unit/mongoose_push_test.exs
@@ -603,13 +603,12 @@ defmodule MongoosePushTest do
 
   defp last_activity(:apns) do
     {:ok, conn} = get_connection(:apns)
-    headers = headers("GET", "/activity")
+    headers = headers("GET", "/mock/activity")
     :h2_client.send_request(conn, headers, "")
 
     get_response(conn)
     |> Poison.decode!()
-    |> Map.get("logs")
-    |> List.last()
+    |> List.first()
   end
 
   defp headers(method, path, payload \\ "") do


### PR DESCRIPTION
As `mobify/apns-http2-mock-server` no longer exists and I was unable to find any good alternative, I created a simple mock (kamilwaz/apns-mock-server) and integrated tests with it. 