### PR TITLE
Replace APNs mock with kamilwaz/apns-mock-server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ executors:
     docker:
       - image: mongooseim/beam-builder:erlang-<< parameters.erlang_version >>_elixir-<< parameters.elixir_version >>
       - image: mongooseim/fcm-mock-server
-      - image: mobify/apns-http2-mock-server
+      - image: kamilwaz/apns-mock-server
     working_directory: ~/app
     environment:
         MIX_ENV: << parameters.env >>
@@ -224,17 +224,18 @@ jobs:
 
   integration-tests:
     machine:
-        image: ubuntu-1604:201903-01
+        image: ubuntu-2004:2022.07.1
     steps:
       - checkout
       - run:
           name: Install elixir
           command: |
-              wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
-              sudo dpkg -i erlang-solutions_1.0_all.deb && \
+              wget https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc && \
+              sudo apt-key add erlang_solutions.asc && \
+              echo 'deb https://packages.erlang-solutions.com/ubuntu focal contrib' | sudo tee /etc/apt/sources.list.d/esl.list && \
               sudo apt-get update && \
-              sudo apt-get install -y esl-erlang=1:21.0 && \
-              sudo apt-get install -y elixir=1.8.0-1
+              sudo apt-get install -y esl-erlang=1:21.3.8.17-1 && \
+              sudo apt-get install -y elixir=1.10.2-1
               wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz && \
               sudo chmod +x dockerize-linux-amd64-v0.6.1.tar.gz && \
               sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz && \

--- a/test/docker/docker-compose.mocks.yml
+++ b/test/docker/docker-compose.mocks.yml
@@ -8,7 +8,7 @@ services:
       - "4001:4001"
       - "4000:4000"
   apns-mock:
-    image: mobify/apns-http2-mock-server
+    image: kamilwaz/apns-mock-server
     container_name: apns-mock
     ports:
       - "2197:2197"

--- a/test/support/api.ex
+++ b/test/support/api.ex
@@ -64,7 +64,7 @@ defmodule MongoosePush.Support.API do
     {:ok, conn} = get_connection(:apns)
     payload = Poison.encode!(json)
 
-    headers = headers("POST", "/error-tokens", payload)
+    headers = headers("POST", "/mock/error-tokens", payload)
     :h2_client.send_request(conn, headers, payload)
     {"200", _payload} = get_response(conn)
     :ok
@@ -81,9 +81,9 @@ defmodule MongoosePush.Support.API do
   def reset(:apns) do
     {:ok, conn} = get_connection(:apns)
     payload = ""
-    headers = headers("POST", "/reset", payload)
+    headers = headers("POST", "/mock/reset", payload)
     :h2_client.send_request(conn, headers, payload)
-    {"200", "OK"} = get_response(conn)
+    {"200", ""} = get_response(conn)
     :ok
   end
 

--- a/test/unit/mongoose_push_test.exs
+++ b/test/unit/mongoose_push_test.exs
@@ -603,13 +603,12 @@ defmodule MongoosePushTest do
 
   defp last_activity(:apns) do
     {:ok, conn} = get_connection(:apns)
-    headers = headers("GET", "/activity")
+    headers = headers("GET", "/mock/activity")
     :h2_client.send_request(conn, headers, "")
 
     get_response(conn)
     |> Poison.decode!()
-    |> Map.get("logs")
-    |> List.last()
+    |> List.first()
   end
 
   defp headers(method, path, payload \\ "") do


### PR DESCRIPTION
As mobify/apns-http2-mock-server no longer exists and I was unable to find any good alternative, I created a simple mock (kamilwaz/apns-mock-server) and integrated tests with it.