### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
 
   integration-tests:
     machine:
-        image: ubuntu-2004:2022.07.1
+        image: ubuntu-2004:current
     steps:
       - checkout
       - run:
@@ -286,7 +286,7 @@ jobs:
 
   gh-pages-deploy:
     machine:
-        image: ubuntu-2004:2022.07.1
+        image: ubuntu-2004:current
     steps:
       - checkout
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN mix do certs.dev, release
 RUN tar -czf mongoose_push.tar.gz -C _build/prod/rel/mongoose_push .
 
 
-FROM debian:sid-slim
+FROM debian:stable-slim
 
 
 # set locales


### PR DESCRIPTION
This PR fixes 2 problems that came out after recent merge to master - https://app.circleci.com/pipelines/github/esl/MongoosePush/1220/workflows/e6b325b1-022b-4fb1-8f26-f3d5adfa2d46.
- some ubuntu CI images are being deprecated - [source](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177)
- docker image could not be built, I used `debian:stable-slim` instead of `debian:sid-slim` for better stability