### PR TITLE
Add hex and rebar in gh-pages-deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,6 +304,7 @@ jobs:
       - restore_cache:
           keys:
               - certs-cache-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}
+      - run: mix local.hex --force && mix local.rebar --force
       - run:
           name: Compile mix deps
           command: mix do deps.get, deps.compile


### PR DESCRIPTION
Link to a CI failure: https://app.circleci.com/pipelines/github/esl/MongoosePush/1229/workflows/9e84f903-a3d1-4a64-bbf3-dca0ea9b3346/jobs/9772