### PR TITLE
Fix and refactor job for publishing documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,9 +313,7 @@ jobs:
           command: |
               git config --global user.email "mongoosepushbot@erlang-solutions.com"
               git config --global user.name "mongoosepushbot"
-      - add_ssh_keys:
-          fingerprints:
-            - "${GH_DEPLOY_KEY}"
+      - add_ssh_keys
       - run:
           name: Generate docs
           command: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MongoosePush
 
-[![Build Status](https://travis-ci.org/esl/MongoosePush.svg?branch=master)](https://travis-ci.org/esl/MongoosePush) [![Coverage Status](https://coveralls.io/repos/github/esl/MongoosePush/badge.svg?branch=master)](https://coveralls.io/github/esl/MongoosePush?branch=master) [![Ebert](https://ebertapp.io/github/esl/MongoosePush.svg)](https://ebertapp.io/github/esl/MongoosePush)
+[![CircleCI](https://circleci.com/gh/esl/MongoosePush.svg?style=shield)](https://app.circleci.com/pipelines/github/esl/MongoosePush?branch=master) [![Coverage Status](https://coveralls.io/repos/github/esl/MongoosePush/badge.svg?branch=master)](https://coveralls.io/github/esl/MongoosePush?branch=master)
 
 **MongoosePush** is a simple, **RESTful** service written in **Elixir**, providing the ability to **send push
 notifications** to `FCM` (Firebase Cloud Messaging) and/or

--- a/lib/mix/tasks/gh_pages_docs.ex
+++ b/lib/mix/tasks/gh_pages_docs.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.GhPagesDocs do
         tag -> prefix_tag(tag)
       end
 
-    # firstly we need to update version.js for the mix docs task
+    # firstly we need to update versions.js for the mix docs task
     update_versions_js(version)
 
     Mix.Task.run("docs")

--- a/lib/mix/tasks/gh_pages_docs.ex
+++ b/lib/mix/tasks/gh_pages_docs.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.GhPagesDocs do
         tag -> prefix_tag(tag)
       end
 
-    # firstly we need to update versions.js for the mix docs task
+    # Firstly we need to update versions.js for the mix docs task
     update_versions_js(version)
 
     Mix.Task.run("docs")
@@ -23,7 +23,8 @@ defmodule Mix.Tasks.GhPagesDocs do
     0 = Mix.shell().cmd("git stash")
     0 = Mix.shell().cmd("git checkout gh-pages")
 
-    # secondly we do it again to avoid git conflicts from git stash pop
+    # Secondly we do it again to recreate it after checkout
+    # It is a simpler way than using git stash pop and resolving conflicts
     update_versions_js(version)
     update_index_html(version)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MongoosePush.Mixfile do
   def project do
     [
       app: :mongoose_push,
-      version: "2.1.1",
+      version: "2.2.0-dev",
       elixir: "~> 1.6",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This PR:
* Updates SSH configuration for the job. I also generated a new key with write permissions and added it to the CircleCI project.
* Updates CI badges.
* Fixes bugs in `gh_pages_docs.ex`.
* Introduces a new way of publishing the "latest" documentation. Now the mix project version between releases is set with the suffix `-dev`. This way we treat it very similarly to the releases while having consistent drop-down list with versions at our documentation site.

I ran the new job on the branch to ensure that it succeeds. They can be viewed [here](https://app.circleci.com/pipelines/github/esl/MongoosePush/1281/workflows/d990551f-1bea-4f09-9696-311ec903b1c5/jobs/10082) for the release `2.1.1` and [here](https://app.circleci.com/pipelines/github/esl/MongoosePush/1290/workflows/56756046-1880-4726-b048-837b09c8a050/jobs/10142) for the latest master.
Generated documentation is available [here](https://esl.github.io/MongoosePush/v2.2.0-dev/readme.html).