### PR TITLE
Update test images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ executors:
     docker:
       - image: hexpm/elixir:<< parameters.elixir_version >>-erlang-<< parameters.erlang_version >>-ubuntu-jammy-20240125
       - image: mongooseim/fcm-mock-server
-      - image: kamilwaz/apns-mock-server
+      - image: ghcr.io/kamilwaz/apns-mock-server:main
     working_directory: ~/app
     environment:
         MIX_ENV: << parameters.env >>

--- a/test/docker/docker-compose.mocks.yml
+++ b/test/docker/docker-compose.mocks.yml
@@ -3,12 +3,12 @@ version: '3'
 services:
   fcm-mock:
     image: mongooseim/fcm-mock-server
-    container_name:  fcm-mock
+    container_name: fcm-mock
     ports:
       - "4001:4001"
       - "4000:4000"
   apns-mock:
-    image: kamilwaz/apns-mock-server
+    image: ghcr.io/kamilwaz/apns-mock-server:main
     container_name: apns-mock
     ports:
       - "2197:2197"


### PR DESCRIPTION
I moved `apns-mock-server` to ghcr.io (the GitHub registry). This pull request updates all old references to the new destination.