### PR TITLE
Fix config resolution

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -36,9 +36,9 @@ config :mongoose_push, :logging,
   level: {:system, :atom, "PUSH_LOGLEVEL", :info},
   format: {:system, :atom, "PUSH_LOGFORMAT", :json}
 
-config :mongoose_push, fcm_enabled: {:system, :boolean, "PUSH_FCM_ENABLED", true}
+config :mongoose_push, fcm_enabled: {:system, :boolean, "PUSH_FCM_ENABLED", false}
 
-config :mongoose_push, apns_enabled: {:system, :boolean, "PUSH_APNS_ENABLED", true}
+config :mongoose_push, apns_enabled: {:system, :boolean, "PUSH_APNS_ENABLED", false}
 
 config :mongoose_push,
   tls_server_cert_validation: {:system, :boolean, "TLS_SERVER_CERT_VALIDATION", true}

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -111,10 +111,10 @@ Environment variables to configure a production release.
 * `PUSH_HTTPS_ACCEPTORS` - Number of TCP acceptors to start
 
 #### General settings:
-* `PUSH_LOGLEVEL` - `debug`/`info`/`warn`/`error` - Log level of the application. `info` is the default one
+* `PUSH_LOGLEVEL` - `debug`/`info`/`warning`/`error` - Log level of the application. `info` is the default one
 * `PUSH_LOGFORMAT` - `logfmt`/`json` - Log format of the application. Defaults to `logfmt` for the `dev` and `test` environments, and to `json` for the `prod` environment.
-* `PUSH_FCM_ENABLED` - `true`/`false` - Enable or disable `FCM` support. Enabled by default
-* `PUSH_APNS_ENABLED` - `true`/`false` - Enable or disable `APNS` support. Enabled by default
+* `PUSH_FCM_ENABLED` - `true`/`false` - Enable or disable `FCM` support. Disabled by default
+* `PUSH_APNS_ENABLED` - `true`/`false` - Enable or disable `APNS` support. Disabled by default
 * `TLS_SERVER_CERT_VALIDATION` - `true`/`false` - Enable or disable TLS
   options for both FCM and APNS.
 * `PUSH_OPENAPI_EXPOSE_SPEC` - `true`/`false` - Enable or disable OpenAPI specification endpoint support. If enabled, it will be available on `/swagger.json` HTTP path. Disabled by default
@@ -149,9 +149,13 @@ Environment variables to configure a production release.
 
 ## TOML schema
 
+  > IMPORTANT:
+  > When a configuration option is defined in TOML file it can't be overwritten by environmental variables.
+  > You can use both methods for different options though. 
+
 #### General keys
 
-* `general.logging.level` (*string*, *optional*) - One of: `debug`/`info`/`warn`/`error`. If not set, falls back to the environment variable `PUSH_LOGLEVEL` or its default.
+* `general.logging.level` (*string*, *optional*) - One of: `debug`/`info`/`warning`/`error`. If not set, falls back to the environment variable `PUSH_LOGLEVEL` or its default.
 * `general.https.bind.addr` (*string*, *optional*) - Bind IP address of the HTTPS endpoint. If not set, falls back to the environment variable `PUSH_HTTPS_BIND_ADDR` or its default.
 * `general.https.bind.port` (*integer*, *optional*) - Port of the HTTPS endpoint. If not set, falls back to the environment variable `PUSH_HTTPS_PORT` or its default.
 * `general.https.num_acceptors` (*integer*, *optional*) - Number of TCP acceptors to start. If not set, falls back to the environment variable `PUSH_HTTPS_ACCEPTORS` or its default.

--- a/lib/mongoose_push/application.ex
+++ b/lib/mongoose_push/application.ex
@@ -211,7 +211,7 @@ defmodule MongoosePush.Application do
       nil ->
         Logger.info("Skipping TOML configuration due to non-release boot",
           what: :toml_configuration,
-          status: :error,
+          status: :skipped,
           reason: :no_release
         )
     end

--- a/lib/mongoose_push/config/provider/confex.ex
+++ b/lib/mongoose_push/config/provider/confex.ex
@@ -2,24 +2,11 @@ defmodule MongoosePush.Config.Provider.Confex do
   @moduledoc false
   @behaviour Config.Provider
 
-  @ignored_apps [:kernel, :stdlib]
-
   @impl true
   def init(opts), do: opts
 
   @impl true
   def load(config, _opts) do
-    new_config =
-      Application.loaded_applications()
-      |> Enum.reject(fn {app, _, _} -> app in @ignored_apps end)
-      |> Enum.map(fn {app, _, _} -> {app, fetch_envs(app)} end)
-
-    Config.Reader.merge(config, new_config)
-  end
-
-  @spec fetch_envs(Application.app()) :: [{Application.key(), Application.value()}]
-  defp fetch_envs(app) do
-    Application.get_all_env(app)
-    |> Enum.map(fn {key, _} -> {key, Confex.fetch_env!(app, key)} end)
+    Confex.Resolver.resolve!(config)
   end
 end

--- a/lib/mongoose_push/config/provider/toml.ex
+++ b/lib/mongoose_push/config/provider/toml.ex
@@ -54,7 +54,8 @@ defmodule MongoosePush.Config.Provider.Toml do
       case toml[:general][:logging][:level] do
         "debug" -> :debug
         "info" -> :info
-        "warn" -> :warn
+        "warn" -> :warning
+        "warning" -> :warning
         "error" -> :error
         nil -> sysconfig[:logging][:level]
         invalid -> raise "Invalid loglevel: #{invalid}!"

--- a/lib/mongoose_push/config/provider/toml.ex
+++ b/lib/mongoose_push/config/provider/toml.ex
@@ -52,8 +52,8 @@ defmodule MongoosePush.Config.Provider.Toml do
   end
 
   defp maybe_erase_confex_services(config, updated_sysconfig) do
-    # If some pools are defined in TOML config we want to remove the default ones explicitely
-    # because Config.Reader.merge/2 would keep them both and the default would still be created
+    # If some pools are defined in TOML config, we want to remove the default ones explicitly
+    # because Config.Reader.merge/2 would keep them both, and the default would still be created
     config
     |> maybe_erase_default_service(:fcm, updated_sysconfig[:fcm_enabled])
     |> maybe_erase_default_service(:apns, updated_sysconfig[:apns_enabled])

--- a/lib/mongoose_push/config/provider/toml.ex
+++ b/lib/mongoose_push/config/provider/toml.ex
@@ -21,7 +21,7 @@ defmodule MongoosePush.Config.Provider.Toml do
         config,
         [
           {@app,
-           Keyword.merge(updated_sysconfig,
+           Keyword.put(updated_sysconfig, :toml_configuration,
              status: {:ok, :loaded},
              path: opts[:path]
            )}
@@ -34,7 +34,7 @@ defmodule MongoosePush.Config.Provider.Toml do
       false ->
         Config.Reader.merge(
           config,
-          [{@app, status: {:ok, :skipped}, path: opts[:path]}]
+          [{@app, [toml_configuration: [status: {:ok, :skipped}, path: :path]]}]
         )
     end
   end

--- a/test/unit/config/toml_test.exs
+++ b/test/unit/config/toml_test.exs
@@ -4,7 +4,7 @@ defmodule MongoosePush.TomlTest do
   alias MongoosePush.Config.Provider.Toml, as: Provider
 
   test "toml overwrites log level" do
-    for level <- [:debug, :info, :warn, :error] do
+    for level <- [:debug, :info, :warning, :error] do
       sysconfig =
         Provider.update_sysconfig(
           default_sysconfig(),

--- a/test/unit/config/toml_test.exs
+++ b/test/unit/config/toml_test.exs
@@ -109,7 +109,7 @@ defmodule MongoosePush.TomlTest do
     assert sysconfig[MongoosePushWeb.Endpoint][:server] == true
   end
 
-  test "toml disables all services by default" do
+  test "toml leaves default services when not defined" do
     sysconfig =
       Provider.update_sysconfig(
         default_sysconfig(),
@@ -120,10 +120,10 @@ defmodule MongoosePush.TomlTest do
         )
       )
 
-    assert sysconfig[:fcm_enabled] == false
-    assert sysconfig[:fcm] == []
-    assert sysconfig[:apns_enabled] == false
-    assert sysconfig[:apns] == []
+    assert sysconfig[:fcm_enabled] == default_sysconfig()[:fcm_enabled]
+    assert sysconfig[:fcm] == default_sysconfig()[:fcm]
+    assert sysconfig[:apns_enabled] == default_sysconfig()[:apns_enabled]
+    assert sysconfig[:apns] == default_sysconfig()[:apns]
   end
 
   test "toml defines fcm pool" do
@@ -152,8 +152,8 @@ defmodule MongoosePush.TomlTest do
         )
       )
 
-    assert sysconfig[:apns_enabled] == false
-    assert sysconfig[:apns] == []
+    assert sysconfig[:apns_enabled] == default_sysconfig()[:apns_enabled]
+    assert sysconfig[:apns] == default_sysconfig()[:apns]
 
     assert sysconfig[:fcm_enabled] == true
     assert sysconfig[:fcm][:fcm_1][:endpoint] == "localhost"
@@ -218,8 +218,8 @@ defmodule MongoosePush.TomlTest do
         )
       )
 
-    assert sysconfig[:fcm_enabled] == false
-    assert sysconfig[:fcm] == []
+    assert sysconfig[:fcm_enabled] == default_sysconfig()[:fcm_enabled]
+    assert sysconfig[:fcm] == default_sysconfig()[:fcm]
 
     assert sysconfig[:apns_enabled] == true
 


### PR DESCRIPTION
This PR changes resolution of configuration environmental variables.
Previously the resolver would iterate over all configuration keys and call `Confex.fetch_env!(app, key)` to resolve all values. The issue with it was that if some keys were already set by TOML resolver they would still be seen as `{:system, type, var_name, default}` which led to overriding TOML config with defaults.
Also, it changes default values of `PUSH_*_ENABLED` to false to avoid implicit creation of an incorrect pool.
At last it fixes a clash where after defining some service pools in TOML file, entries from `prod.exs` would be appended to them due to the behaviour of `Config.Reader.merge/2`. If someone defines pools in TOML file then no other pools should be created.