### PR TITLE
Fix token path resolution

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -156,6 +156,7 @@ Environment variables to configure a production release.
 #### General keys
 
 * `general.logging.level` (*string*, *optional*) - One of: `debug`/`info`/`warning`/`error`. If not set, falls back to the environment variable `PUSH_LOGLEVEL` or its default.
+* `general.logging.format` (*string*, *optional*) - One of: `logfmt`/`json` - Log format of the application. If not set, falls back to the environment variable `PUSH_LOGFORMAT` or its default.
 * `general.https.bind.addr` (*string*, *optional*) - Bind IP address of the HTTPS endpoint. If not set, falls back to the environment variable `PUSH_HTTPS_BIND_ADDR` or its default.
 * `general.https.bind.port` (*integer*, *optional*) - Port of the HTTPS endpoint. If not set, falls back to the environment variable `PUSH_HTTPS_PORT` or its default.
 * `general.https.num_acceptors` (*integer*, *optional*) - Number of TCP acceptors to start. If not set, falls back to the environment variable `PUSH_HTTPS_ACCEPTORS` or its default.

--- a/lib/mongoose_push/application.ex
+++ b/lib/mongoose_push/application.ex
@@ -139,12 +139,22 @@ defmodule MongoosePush.Application do
     Enum.map(config, fn {key, value} ->
       case Enum.member?(path_keys, key) do
         true ->
-          {key, Application.app_dir(:mongoose_push, value)}
+          {key, resolve_path(value)}
 
         false ->
           {key, value}
       end
     end)
+  end
+
+  defp resolve_path(path) do
+    case Path.type(path) do
+      :absolute ->
+        path
+
+      :relative ->
+        Application.app_dir(:mongoose_push, path)
+    end
   end
 
   defp ensure_tls_opts(config) do

--- a/test/unit/mongoose_push_test.exs
+++ b/test/unit/mongoose_push_test.exs
@@ -358,7 +358,8 @@ defmodule MongoosePushTest do
           type: :token,
           key_id: "fake_key",
           team_id: "fake_team",
-          p8_file_path: "priv/apns/token.p8"
+          # We test if the pool will be created without error with absolute path
+          p8_file_path: Application.app_dir(:mongoose_push, "priv/apns/token.p8")
         },
         endpoint: "localhost",
         mode: :prod,


### PR DESCRIPTION
This PR fixes issue when an absolute path to auth tokens/certs for APNS/FCM was given it would still prefix it with application root path. From now it will allow users to specify either absolute or relative path and it should be resolved correctly.
Additionally I added a small missing entry in documentation.