### PR TITLE
Add migration guides

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,12 +225,11 @@ jobs:
       - run:
           name: Install elixir
           command: |
-              wget https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc && \
-              sudo apt-key add erlang_solutions.asc && \
-              echo 'deb https://packages.erlang-solutions.com/ubuntu focal contrib' | sudo tee /etc/apt/sources.list.d/esl.list && \
+              curl -1sLf 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/setup.deb.sh' | sudo -E bash && \
               sudo apt-get update && \
-              sudo apt-get install -y esl-erlang=1:24.3.3-1 && \
-              sudo apt-get install -y elixir=1.13.0-1
+              sudo apt-get install -y erlang && \
+              sudo apt-get install -y elixir &&\
+              elixir -v
               wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz && \
               sudo chmod +x dockerize-linux-amd64-v0.6.1.tar.gz && \
               sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
 
   integration-tests:
     machine:
-        image: ubuntu-2004:current
+        image: ubuntu-2404:current
     steps:
       - checkout
       - run:

--- a/guides/migrations/2.1.1_2.1.2.md
+++ b/guides/migrations/2.1.1_2.1.2.md
@@ -1,0 +1,31 @@
+# Migration guide from 2.1.1 to 2.1.2
+
+## Configuration via environmental variables
+
+Configuration options `PUSH_APNS_ENABLED` and `PUSH_FCM_ENABLED` have changed their default value from `true` to `false`.
+In case of a deployment (e.g. with Docker) where those variables were not set,
+to keep the same behaviour they need to be explicitly set to `true`.
+
+### Example
+
+Old way of running MongoosePush with Docker:
+
+```bash
+docker run -v `pwd`/priv:/opt/app/priv \
+  -v `pwd`/var:/opt/app/var \
+  -e PUSH_HTTPS_CERTFILE="/opt/app/priv/ssl/rest_cert.pem" \
+  -e PUSH_HTTPS_KEYFILE="/opt/app/priv/ssl/rest_key.pem" \
+  -it --rm mongooseim/mongoose-push:2.1.1
+```
+
+Now it has to be:
+
+```bash
+docker run -v `pwd`/priv:/opt/app/priv \
+  -v `pwd`/var:/opt/app/var \
+  -e PUSH_HTTPS_CERTFILE="/opt/app/priv/ssl/rest_cert.pem" \
+  -e PUSH_HTTPS_KEYFILE="/opt/app/priv/ssl/rest_key.pem" \
+  -e PUSH_APNS_ENABLED=true \
+  -e PUSH_FCM_ENABLED=true \
+  -it --rm mongooseim/mongoose-push:2.1.2
+```

--- a/mix.exs
+++ b/mix.exs
@@ -78,9 +78,13 @@ defmodule MongoosePush.Mixfile do
         "guides/docker.md": [file: "guides/docker", title: "Docker"],
         "guides/http_api.md": [file: "guides/http_api", title: "HTTP API"],
         "guides/healthcheck.md": [file: "guides/healthcheck", title: "Healthcheck"],
-        "guides/metrics.md": [file: "guides/metrics", title: "Metrics"]
+        "guides/metrics.md": [file: "guides/metrics", title: "Metrics"],
+        "guides/migrations/2.0.x_2.1.0.md": [file: "guides/migrationts/2.0.x_2.1.0", title: "2.0.x to 2.1.0"]
+        ],
+      groups_for_extras: [
+        "Guides": Path.wildcard("guides/*.md"),
+        "Migration Guides": Path.wildcard("guides/migrations/*.md")
       ],
-      extra_section: "Guides",
       groups_for_modules: [
         API: [
           MongoosePush.API,

--- a/mix.exs
+++ b/mix.exs
@@ -79,7 +79,8 @@ defmodule MongoosePush.Mixfile do
         "guides/http_api.md": [file: "guides/http_api", title: "HTTP API"],
         "guides/healthcheck.md": [file: "guides/healthcheck", title: "Healthcheck"],
         "guides/metrics.md": [file: "guides/metrics", title: "Metrics"],
-        "guides/migrations/2.0.x_2.1.0.md": [file: "guides/migrationts/2.0.x_2.1.0", title: "2.0.x to 2.1.0"]
+        "guides/migrations/2.0.x_2.1.0.md": [file: "guides/migrationts/2.0.x_2.1.0", title: "2.0.x to 2.1.0"],
+        "guides/migrations/2.1.1_2.1.2.md": [file: "guides/migrationts/2.1.1_2.1.2", title: "2.1.1 to 2.1.2"]
         ],
       groups_for_extras: [
         "Guides": Path.wildcard("guides/*.md"),

--- a/mix.exs
+++ b/mix.exs
@@ -79,11 +79,17 @@ defmodule MongoosePush.Mixfile do
         "guides/http_api.md": [file: "guides/http_api", title: "HTTP API"],
         "guides/healthcheck.md": [file: "guides/healthcheck", title: "Healthcheck"],
         "guides/metrics.md": [file: "guides/metrics", title: "Metrics"],
-        "guides/migrations/2.0.x_2.1.0.md": [file: "guides/migrationts/2.0.x_2.1.0", title: "2.0.x to 2.1.0"],
-        "guides/migrations/2.1.1_2.1.2.md": [file: "guides/migrationts/2.1.1_2.1.2", title: "2.1.1 to 2.1.2"]
+        "guides/migrations/2.0.x_2.1.0.md": [
+          file: "guides/migrationts/2.0.x_2.1.0",
+          title: "2.0.x to 2.1.0"
         ],
+        "guides/migrations/2.1.1_2.1.2.md": [
+          file: "guides/migrationts/2.1.1_2.1.2",
+          title: "2.1.1 to 2.1.2"
+        ]
+      ],
       groups_for_extras: [
-        "Guides": Path.wildcard("guides/*.md"),
+        Guides: Path.wildcard("guides/*.md"),
         "Migration Guides": Path.wildcard("guides/migrations/*.md")
       ],
       groups_for_modules: [


### PR DESCRIPTION
This PR add "Migration Guides" section to the hex documentation. Also, it attaches previous migration guide that was in the repository but not published and adds a migration guide from 2.1.1 to 2.2.2.
 To check how does it look run `mix docs` and open `doc/index.html` file.