### PR TITLE
Fix gh pages deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,8 +228,7 @@ jobs:
               curl -1sLf 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/setup.deb.sh' | sudo -E bash && \
               sudo apt-get update && \
               sudo apt-get install -y erlang && \
-              sudo apt-get install -y elixir &&\
-              elixir -v
+              sudo apt-get install -y elixir
               wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz && \
               sudo chmod +x dockerize-linux-amd64-v0.6.1.tar.gz && \
               sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,12 +290,10 @@ jobs:
       - run:
           name: Install elixir
           command: |
-              wget https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc && \
-              sudo apt-key add erlang_solutions.asc && \
-              echo 'deb https://packages.erlang-solutions.com/ubuntu focal contrib' | sudo tee /etc/apt/sources.list.d/esl.list && \
+              curl -1sLf 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/setup.deb.sh' | sudo -E bash && \
               sudo apt-get update && \
-              sudo apt-get install -y esl-erlang=1:24.3.3-1 && \
-              sudo apt-get install -y elixir=1.13.0-1
+              sudo apt-get install -y erlang && \
+              sudo apt-get install -y elixir
       - restore_cache:
           keys:
               - mix-cache-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}


### PR DESCRIPTION
This PR is a follow-up to https://github.com/esl/MongoosePush/pull/220. It fixes `gh-pages-deploy` job which runs only on master branch. The fix is similar to the one before for `integration-tests`, i.e. install Erlang and Elixir from rabbitmq repository instead of esl.