### PR TITLE
Dry run docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,4 +378,4 @@ workflows:
             tags:
               only: /^\d+\.\d+\.\d+([a-z0-9\-\+\.])*/
             branches:
-              only: master
+              ignore: gh-pages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
 
   gh-pages-deploy:
     machine:
-        image: ubuntu-2004:current
+        image: ubuntu-2404:current
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,6 +318,8 @@ jobs:
                   mix gh_pages_docs $CIRCLE_TAG
               elif [ "$CIRCLE_BRANCH" == "master" ]; then
                   mix gh_pages_docs latest
+              else
+                  mix gh_pages_docs dry
               fi
 
 

--- a/lib/mix/tasks/gh_pages_docs.ex
+++ b/lib/mix/tasks/gh_pages_docs.ex
@@ -9,10 +9,11 @@ defmodule Mix.Tasks.GhPagesDocs do
 
   @spec run([String.t()]) :: :ok
   def run([version]) do
-    version =
+    {version, dry} =
       case version do
-        "latest" -> prefix_tag(Mix.Project.config()[:version])
-        tag -> prefix_tag(tag)
+        "dry" -> {prefix_tag(Mix.Project.config()[:version]), true}
+        "latest" -> {prefix_tag(Mix.Project.config()[:version]), false}
+        tag -> {prefix_tag(tag), false}
       end
 
     # Firstly we need to update versions.js for the mix docs task
@@ -38,7 +39,10 @@ defmodule Mix.Tasks.GhPagesDocs do
         0 = Mix.shell().cmd("git add assets/js/versions.js")
         0 = Mix.shell().cmd("git add index.html")
         0 = Mix.shell().cmd("git commit -m \"Add content for #{version}\"")
-        0 = Mix.shell().cmd("git push origin gh-pages")
+
+        if not dry do
+          0 = Mix.shell().cmd("git push origin gh-pages")
+        end
 
       _ ->
         Mix.raise("Cannot create the #{version} directory")


### PR DESCRIPTION
This PR add dry-run of the `gh-pages-deploy` CI job. It allows to run and debug it on any branch which should spare us follow-up fixes after it fails on master branch.
Additionally it is fixed by bumping ubuntu version of the executor.