### PR TITLE
Build multiplatform docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,8 +298,6 @@ jobs:
   gh-pages-deploy:
     docker:
       - image: cimg/elixir:1.18.3-erlang-27.2.2
-        environment:
-          MIX_ENV: dev
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,23 @@ jobs:
       env: prod
     steps:
       - checkout
-      - run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io
+      - run:
+          name: Install docker and buildx
+          command: |
+            apt update
+            apt install ca-certificates curl -y
+            install -m 0755 -d /etc/apt/keyrings
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+            chmod a+r /etc/apt/keyrings/docker.asc
+            tee /etc/apt/sources.list.d/docker.sources \<<EOF
+            Types: deb
+            URIs: https://download.docker.com/linux/ubuntu
+            Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+            Components: stable
+            Signed-By: /etc/apt/keyrings/docker.asc
+            EOF
+            apt update
+            DEBIAN_FRONTEND=noninteractive apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
       - setup_remote_docker:
           docker_layer_caching: true
       - restore_cache:
@@ -209,13 +225,10 @@ jobs:
           command: docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
       - run:
           name: Build docker image
-          command: docker build -f Dockerfile --build-arg MIX_ENV=prod -t mpush:latest .
-      - run:
-          name: Push docker image but do not tag it as the latest
-          command: docker tag mpush:latest $DOCKERHUB_REPOSITORY/$DOCKER_IMAGE:$DOCKER_TAG
-      - run:
-          name: Push docker image but do not tag it as the latest
-          command: docker push $DOCKERHUB_REPOSITORY/$DOCKER_IMAGE:$DOCKER_TAG
+          command: |
+            docker run --privileged --rm tonistiigi/binfmt --install all
+            docker buildx create --name builder --driver docker-container --bootstrap --use
+            docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile --build-arg MIX_ENV=prod -t $DOCKERHUB_REPOSITORY/$DOCKER_IMAGE:$DOCKER_TAG --push .
 
   integration-tests:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,17 +296,12 @@ jobs:
              fi
 
   gh-pages-deploy:
-    machine:
-        image: ubuntu-2404:current
+    docker:
+      - image: cimg/elixir:1.18.3-erlang-27.2.2
+        environment:
+          MIX_ENV: dev
     steps:
       - checkout
-      - run:
-          name: Install elixir
-          command: |
-              curl -1sLf 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/setup.deb.sh' | sudo -E bash && \
-              sudo apt-get update && \
-              sudo apt-get install -y erlang=1:27.3.4.1-1 && \
-              sudo apt-get install -y elixir
       - restore_cache:
           keys:
               - mix-cache-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,16 +236,16 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install elixir
+          name: Install Erlang, Elixir and dockerize
           command: |
-              curl -1sLf 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/setup.deb.sh' | sudo -E bash && \
-              sudo apt-get update && \
-              sudo apt-get install -y erlang=1:27.3.4.1-1 && \
-              sudo apt-get install -y elixir
-              wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz && \
-              sudo chmod +x dockerize-linux-amd64-v0.6.1.tar.gz && \
-              sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz && \
-              sudo chmod +x /usr/local/bin/dockerize && \
+              sudo add-apt-repository ppa:rabbitmq/rabbitmq-erlang -y
+              sudo apt update
+              sudo apt-get install -y erlang=1:27.3.4.6-1rmq1ppa1~ubuntu24.04.1
+              sudo apt-get install -y elixir=1.17.3-1rmq1ppa1~ubuntu24.04.1
+              wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz
+              sudo chmod +x dockerize-linux-amd64-v0.6.1.tar.gz
+              sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz
+              sudo chmod +x /usr/local/bin/dockerize
               sudo rm dockerize-linux-amd64-v0.6.1.tar.gz
       - run: docker-compose -v
       - restore_cache:


### PR DESCRIPTION
This PR introduces building multiplatform docker images with `buildx`. Also, it fixes `integration-tests` and `gh-pages-deploy` jobs which started to fail due to debian package issues.
Details in the commit messages.