### PR TITLE
Fix failing intergration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ run: &DOCKER_TAGS
         echo "export DOCKER_IMAGE=mongoose-push" >> $BASH_ENV
 
 executors:
-  elixir-builder:
+  elixir-builder: &elixir-builder
     parameters:
       erlang_version:
         type: string
@@ -35,26 +35,25 @@ executors:
         default: test
     docker:
       - image: hexpm/elixir:<< parameters.elixir_version >>-erlang-<< parameters.erlang_version >>-ubuntu-noble-20250415.1
-      - image: erlangsolutions/fcm-mock-server
-      - image: erlangsolutions/apns-mock-server
     working_directory: ~/app
     environment:
         MIX_ENV: << parameters.env >>
+  elixir-env:
+    <<: *elixir-builder
+    docker:
+      - image: hexpm/elixir:<< parameters.elixir_version >>-erlang-<< parameters.erlang_version >>-ubuntu-noble-20250415.1
+      - image: erlangsolutions/fcm-mock-server
+      - image: erlangsolutions/apns-mock-server
 
 commands:
   test:
     steps:
       - checkout
       - run:
-          name: Install dockerize
+          name: Install deps
           command: |
-            apt-get update && apt-get install -y wget && \
-            wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz && \
-            chmod +x dockerize-linux-amd64-v0.6.1.tar.gz && \
-            tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz && \
-            chmod +x /usr/local/bin/dockerize && \
-            rm dockerize-linux-amd64-v0.6.1.tar.gz
-      - run: apt-get update && apt-get install -y git
+            apt update
+            apt install -y git netcat-openbsd
       - restore_cache:
           keys:
             - mix-cache-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}
@@ -63,10 +62,10 @@ commands:
             - build-${CIRCLE_JOB}-cache-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Wait for FCM mock
-          command: dockerize -wait tcp://localhost:4000 -timeout 1m
+          command: timeout 60 bash -c 'until nc -z localhost 4000; do sleep 5; done'
       - run:
           name: Wait for APNS mock
-          command: dockerize -wait tcp://localhost:2197 -timeout 1m
+          command: timeout 60 bash -c 'until nc -z localhost 2197; do sleep 5; done'
 
       - run: MIX_ENV=test mix do local.rebar, certs.dev, coveralls.circle
 
@@ -171,7 +170,7 @@ jobs:
 
   test-erlang-27_elixir-1-18:
     executor:
-      name: elixir-builder
+      name: elixir-env
       env: test
       erlang_version: "27.3.4"
       elixir_version: "1.18.3"
@@ -180,7 +179,7 @@ jobs:
 
   test-erlang-27_elixir-1-17:
     executor:
-      name: elixir-builder
+      name: elixir-env
       env: test
       erlang_version: "27.3.4"
       elixir_version: "1.17.3"
@@ -189,7 +188,7 @@ jobs:
 
   test-erlang-26_elixir-1-18:
     executor:
-      name: elixir-builder
+      name: elixir-env
       env: test
       erlang_version: "26.2.5.12"
       elixir_version: "1.18.3"
@@ -198,7 +197,7 @@ jobs:
 
   test-erlang-26_elixir-1-17:
     executor:
-      name: elixir-builder
+      name: elixir-env
       env: test
       erlang_version: "26.2.5.12"
       elixir_version: "1.17.3"
@@ -240,22 +239,15 @@ jobs:
 
   integration-tests:
     machine:
-        image: ubuntu-2404:current
+      image: ubuntu-2404:current
     steps:
       - checkout
       - run:
-          name: Install Erlang, Elixir and dockerize
+          name: Install deps
           command: |
-              sudo add-apt-repository ppa:rabbitmq/rabbitmq-erlang -y
-              sudo apt update
-              sudo apt-get install -y erlang
-              sudo apt-get install -y elixir
-              wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz
-              sudo chmod +x dockerize-linux-amd64-v0.6.1.tar.gz
-              sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz
-              sudo chmod +x /usr/local/bin/dockerize
-              sudo rm dockerize-linux-amd64-v0.6.1.tar.gz
-      - run: docker-compose -v
+            sudo add-apt-repository ppa:rabbitmq/rabbitmq-erlang -y
+            sudo apt update
+            sudo apt-get install -y erlang elixir
       - restore_cache:
           keys:
               - mix-cache-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
     parameters:
       erlang_version:
         type: string
-        default: "27.3.4"
+        default: "27.2.2"
       elixir_version:
         type: string
         default: "1.18.3"
@@ -34,14 +34,14 @@ executors:
         type: string
         default: test
     docker:
-      - image: hexpm/elixir:<< parameters.elixir_version >>-erlang-<< parameters.erlang_version >>-ubuntu-noble-20250415.1
+      - image: cimg/elixir:<< parameters.elixir_version >>-erlang-<< parameters.erlang_version >>
     working_directory: ~/app
     environment:
         MIX_ENV: << parameters.env >>
   elixir-env:
     <<: *elixir-builder
     docker:
-      - image: hexpm/elixir:<< parameters.elixir_version >>-erlang-<< parameters.erlang_version >>-ubuntu-noble-20250415.1
+      - image: cimg/elixir:<< parameters.elixir_version >>-erlang-<< parameters.erlang_version >>
       - image: erlangsolutions/fcm-mock-server
       - image: erlangsolutions/apns-mock-server
 
@@ -52,8 +52,8 @@ commands:
       - run:
           name: Install deps
           command: |
-            apt update
-            apt install -y git netcat-openbsd
+            sudo apt update
+            sudo apt install -y git netcat-openbsd
       - restore_cache:
           keys:
             - mix-cache-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}
@@ -76,30 +76,36 @@ commands:
       - store_artifacts:
           path: cover
           destination: coverage_results
+  install_deps:
+    steps:
+      - run:
+          name: Install deps
+          command: |
+            sudo apt update
+            sudo apt install -y git
   install_docker:
     steps:
       - run:
           name: Install docker repository key
           command: |
-            apt update
-            apt install ca-certificates curl -y
-            install -m 0755 -d /etc/apt/keyrings
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-            chmod a+r /etc/apt/keyrings/docker.asc
+            sudo apt update
+            sudo apt install ca-certificates curl -y
+            sudo install -m 0755 -d /etc/apt/keyrings
+            sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
       - run:
           name: Add docker repository
           command: |
-            tee /etc/apt/sources.list.d/docker.sources \<<EOF
+            sudo tee /etc/apt/sources.list.d/docker.sources \<<EOF
             Types: deb
             URIs: https://download.docker.com/linux/ubuntu
             Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
             Components: stable
             Signed-By: /etc/apt/keyrings/docker.asc
             EOF
-            apt update
+            sudo apt update
       - run:
           name: Install docker and plugins
-          command: DEBIAN_FRONTEND=noninteractive apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+          command: DEBIAN_FRONTEND=noninteractive sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 
 jobs:
   pre-build:
@@ -107,7 +113,7 @@ jobs:
 
     steps:
       - checkout
-      - run: apt-get update && apt-get install -y git
+      - install_deps
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get
@@ -123,7 +129,7 @@ jobs:
     executor: elixir-builder
     steps:
       - checkout
-      - run: apt-get update && apt-get install -y git
+      - install_deps
       - run: echo "$OTP_VERSION $ELIXIR_VERSION" > .version_file
       - restore_cache:
           keys:
@@ -150,8 +156,6 @@ jobs:
     executor:
       name: elixir-builder
       env: dev
-      erlang_version: "26.2"
-      elixir_version: "1.16"
     steps:
       - checkout
       - restore_cache:
@@ -172,7 +176,7 @@ jobs:
     executor:
       name: elixir-env
       env: test
-      erlang_version: "27.3.4"
+      erlang_version: "27.2.2"
       elixir_version: "1.18.3"
     steps:
       - test
@@ -181,7 +185,7 @@ jobs:
     executor:
       name: elixir-env
       env: test
-      erlang_version: "27.3.4"
+      erlang_version: "27.2.2"
       elixir_version: "1.17.3"
     steps:
       - test
@@ -190,7 +194,7 @@ jobs:
     executor:
       name: elixir-env
       env: test
-      erlang_version: "26.2.5.12"
+      erlang_version: "26.2.1"
       elixir_version: "1.18.3"
     steps:
       - test
@@ -199,7 +203,7 @@ jobs:
     executor:
       name: elixir-env
       env: test
-      erlang_version: "26.2.5.12"
+      erlang_version: "26.2.1"
       elixir_version: "1.17.3"
     steps:
       - test
@@ -243,7 +247,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install deps
+          name: Install Elixir
           command: |
             sudo add-apt-repository ppa:rabbitmq/rabbitmq-erlang -y
             sudo apt update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,8 +248,8 @@ jobs:
           command: |
               sudo add-apt-repository ppa:rabbitmq/rabbitmq-erlang -y
               sudo apt update
-              sudo apt-get install -y erlang=1:27.3.4.6-1rmq1ppa1~ubuntu24.04.1
-              sudo apt-get install -y elixir=1.17.3-1rmq1ppa1~ubuntu24.04.1
+              sudo apt-get install -y erlang
+              sudo apt-get install -y elixir
               wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz
               sudo chmod +x dockerize-linux-amd64-v0.6.1.tar.gz
               sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 dashboards:
-	docker-compose -f test/docker/docker-compose.dashboard.yml up -d --build
+	docker compose -f test/docker/docker compose.dashboard.yml up -d --build
 
 update-dashboards:
 	./test/docker/grafana/update-dashboards.sh
@@ -7,4 +7,4 @@ update-dashboards:
 .PHONY: run update-dashboards
 
 clean-dashboards:
-	docker-compose -f test/docker/docker-compose.dashboard.yml down
+	docker compose -f test/docker/docker compose.dashboard.yml down

--- a/guides/local_build.md
+++ b/guides/local_build.md
@@ -36,7 +36,7 @@ The development release is by default configured to connect to a local APNS / FC
 This configuration may be changed as needed in the `config/dev.exs` file.
 For now, let's just start those mocks so that we can use the default dev configuration:
 ```bash
-docker-compose -f test/docker/docker-compose.mocks.yml up -d
+docker compose -f test/docker/docker compose.mocks.yml up -d
 ```
 
 After this step you may try to run the service via:

--- a/guides/test.md
+++ b/guides/test.md
@@ -6,7 +6,7 @@ One thing that you need to do *once* before running any tests is generating fake
 mix certs.dev
 ```
 
-Also, you'll need to have `docker-compose` installed and present in your path to run any tests.
+Also, you'll need to have `docker` installed and present in your path to run any tests.
 
 ## TL;DR
 
@@ -60,8 +60,8 @@ MIX_ENV=integration mix test.env.down
 
 ## Test environment setup
 
-* `mix test.env.up` - runs `docker-compose up -d --build` with the following compose files:
-  * for `MIX_ENV=test` and `MIX_ENV=dev`: *test/docker/docker-compose.mocks.yml*
-  * for `MIX_ENV=integration`: *test/docker/docker-compose.mocks.yml* and *test/docker/docker-compose.mpush.yml*
-* `mix test.env.down` - runs `docker-compose down` on the same compose files as `mix test.env.up`
+* `mix test.env.up` - runs `docker compose up -d --build` with the following compose files:
+  * for `MIX_ENV=test` and `MIX_ENV=dev`: *test/docker/docker compose.mocks.yml*
+  * for `MIX_ENV=integration`: *test/docker/docker compose.mocks.yml* and *test/docker/docker compose.mpush.yml*
+* `mix test.env.down` - runs `docker compose down` on the same compose files as `mix test.env.up`
 * `mix test.env.wait X` - waits up to X milliseconds for the services from `mix test.env.up` to become available. Prints an error if they don't.

--- a/test/docker/docker-compose.dashboard.yml
+++ b/test/docker/docker-compose.dashboard.yml
@@ -1,5 +1,5 @@
-# This file needs to be used along with `docker-compose.mocks.yml` and `docker-compose.mpush.yml:
-# PRIV=priv docker-compose -f test/docker/docker-compose.mocks.yml -f test/docker/docker-compose.mpush.yml -f test/docker/docker-compose.prometheus.yml ...
+# This file needs to be used along with `docker compose.mocks.yml` and `docker compose.mpush.yml:
+# PRIV=priv docker compose -f test/docker/docker compose.mocks.yml -f test/docker/docker compose.mpush.yml -f test/docker/docker compose.prometheus.yml ...
 version: '3'
 
 services:

--- a/test/docker/docker-compose.mpush.yml
+++ b/test/docker/docker-compose.mpush.yml
@@ -1,5 +1,5 @@
-# This file needs to be used along with `docker-compose.mocks.yml`:
-# PRIV=priv docker-compose -f test/docker/docker-compose.mocks.yml -f test/docker/docker-compose.mpush.yml ...
+# This file needs to be used along with `docker compose.mocks.yml`:
+# PRIV=priv docker compose -f test/docker/docker compose.mocks.yml -f test/docker/docker compose.mpush.yml ...
 version: '3'
 
 services:

--- a/test/support/mix/tasks/test_env/utils.ex
+++ b/test/support/mix/tasks/test_env/utils.ex
@@ -1,12 +1,12 @@
 defmodule Mix.Tasks.Test.Env.Utils do
-  def compose(compose_binary, opcode_args) do
+  def compose(docker_binary, opcode_args) do
     Mix.shell().info(
-      "Running `docker-compose #{Enum.join(opcode_args, " ")}` for: #{inspect(compose_files(Mix.env()))}"
+      "Running `docker compose #{Enum.join(opcode_args, " ")}` for: #{inspect(compose_files(Mix.env()))}"
     )
 
-    compose_args = base_compose_args() ++ opcode_args ++ ["--remove-orphans"]
+    docker_args = List.flatten(["compose", base_compose_args(), opcode_args, "--remove-orphans"])
 
-    case System.cmd(compose_binary, compose_args, env: [{"PRIV", "../../priv"}]) do
+    case System.cmd(docker_binary, docker_args, env: [{"PRIV", "../../priv"}]) do
       {_output, 0} ->
         :ok
 
@@ -55,8 +55,8 @@ defmodule Mix.Tasks.Test.Env.Utils do
   defp wait_for_services(host, [{proto, port} | _rest], _) do
     flunk("""
     Unable to connect to #{proto}://#{host}:#{port}! Make sure you run `MIX_ENV=#{Mix.env()} mix test.env.up` if you haven't already.
-    If you have - you can run the following command to see the docker-compose logs:
-    $ docker-compose #{Enum.join(base_compose_args(), " ")} logs
+    If you have - you can run the following command to see the docker compose logs:
+    $ docker compose #{Enum.join(base_compose_args(), " ")} logs
     """)
   end
 

--- a/test/support/mix/tasks/test_env_down.ex
+++ b/test/support/mix/tasks/test_env_down.ex
@@ -3,16 +3,16 @@ defmodule Mix.Tasks.Test.Env.Down do
 
   alias Mix.Tasks.Test.Env.Utils
 
-  @shortdoc "Stops test/test.integration dependencies via docker-compose"
+  @shortdoc "Stops test/test.integration dependencies via docker compose"
 
   @spec run(term) :: :ok
   def run(_args) do
-    case System.find_executable("docker-compose") do
+    case System.find_executable("docker") do
       nil ->
-        Utils.flunk("`docker-compose` binary has to be present in your PATH!")
+        Utils.flunk("`docker` binary has to be present in your PATH!")
 
-      compose_binary ->
-        :ok = Utils.compose(compose_binary, ["down"])
+      docker_binary ->
+        :ok = Utils.compose(docker_binary, ["down"])
     end
   end
 end

--- a/test/support/mix/tasks/test_env_up.ex
+++ b/test/support/mix/tasks/test_env_up.ex
@@ -3,16 +3,16 @@ defmodule Mix.Tasks.Test.Env.Up do
 
   alias Mix.Tasks.Test.Env.Utils
 
-  @shortdoc "Starts test/test.integration dependencies via docker-compose"
+  @shortdoc "Starts test/test.integration dependencies via docker compose"
 
   @spec run(term) :: :ok
   def run(_args) do
-    case System.find_executable("docker-compose") do
+    case System.find_executable("docker") do
       nil ->
-        Utils.flunk("`docker-compose` binary has to be present in your PATH!")
+        Utils.flunk("`docker` binary has to be present in your PATH!")
 
-      compose_binary ->
-        :ok = Utils.compose(compose_binary, ["up", "--build", "-d"])
+      docker_binary ->
+        :ok = Utils.compose(docker_binary, ["up", "--build", "-d"])
     end
   end
 end


### PR DESCRIPTION
Integration tests are failing with the following error:

```
E: Version '1:27.3.4.6-1rmq1ppa1~ubuntu24.04.1' for 'erlang' was not found
```

This PR relaxes the version matches, so the latest packages are installed, which should always come from the PPA:

```bash
$ docker run -it --rm ubuntu:24.04
apt update
apt install -y software-properties-common
apt update
apt policy erlang
```
```
erlang:
  Installed: (none)
  Candidate: 1:27.3.4.7-1rmq1ppa1~ubuntu24.04.1
  Version table:
     1:27.3.4.7-1rmq1ppa1~ubuntu24.04.1 500
        500 https://ppa.launchpadcontent.net/rabbitmq/rabbitmq-erlang/ubuntu noble/main arm64 Packages
     1:25.3.2.8+dfsg-1ubuntu4.6 500
        500 http://ports.ubuntu.com/ubuntu-ports noble-updates/universe arm64 Packages
        500 http://ports.ubuntu.com/ubuntu-ports noble-security/universe arm64 Packages
     1:25.3.2.8+dfsg-1ubuntu4 500
        500 http://ports.ubuntu.com/ubuntu-ports noble/universe arm64 Packages
```
\
This PR also simplifies the CircleCI configuration and replaces `docker-compose` with `docker compose`.

MIM-2578